### PR TITLE
Remove Rust install step from CI as it is installed by default

### DIFF
--- a/.github/workflows/node-hub-ci-cd.yml
+++ b/.github/workflows/node-hub-ci-cd.yml
@@ -85,13 +85,6 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up Rust
-        if: runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
       - name: Run Linting and Tests
         ## Run Linting and testing only on Mac for release workflows.
         if: runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))


### PR DESCRIPTION
The [`actions-rs/toolchain` action](https://github.com/actions-rs/toolchain) is archived since 2023 and no longer maintained. Given that GitHub actions runners have Rust installed by default it is also no longer needed, so we can just remove it.