### PR TITLE
fix(node-hub): relax numpy version constraints for vision-related nodes

### DIFF
--- a/node-hub/dora-internvl/pyproject.toml
+++ b/node-hub/dora-internvl/pyproject.toml
@@ -13,7 +13,8 @@ requires-python = ">=3.8"
 dependencies = [
 
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "torch >= 2.7.0",
   "torchvision >= 0.22",
   "torchaudio >= 2.7.0",

--- a/node-hub/dora-pyorbbecksdk/pyproject.toml
+++ b/node-hub/dora-pyorbbecksdk/pyproject.toml
@@ -10,7 +10,12 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["dora-rs >= 0.3.9", "numpy < 2.0.0", "opencv-python >= 4.1.1"]
+dependencies = [
+  "dora-rs >= 0.3.9",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
+  "opencv-python >= 4.1.1"
+]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]

--- a/node-hub/dora-pyrealsense/pyproject.toml
+++ b/node-hub/dora-pyrealsense/pyproject.toml
@@ -9,7 +9,8 @@ requires-python = ">=3.8"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "opencv-python >= 4.1.1",
   "pyrealsense2-macosx >= 2.54.2; sys_platform == 'darwin'",
   "pyrealsense2 >= 2.54.2.5684; sys_platform == 'linux'",

--- a/node-hub/dora-qwen2-5-vl/pyproject.toml
+++ b/node-hub/dora-qwen2-5-vl/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.10"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "torch >= 2.7.0",
   "torchvision >= 0.22",
   "torchaudio >= 2.7.0",

--- a/node-hub/opencv-plot/pyproject.toml
+++ b/node-hub/opencv-plot/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.8"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "opencv-python >= 4.1.1",
   "pillow-avif-plugin>=1.5.1",
   "pillow>=10.4.0",

--- a/node-hub/opencv-video-capture/pyproject.toml
+++ b/node-hub/opencv-video-capture/pyproject.toml
@@ -10,7 +10,12 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["dora-rs >= 0.3.9", "numpy", "opencv-python >= 4.1.1"]
+dependencies = [
+  "dora-rs >= 0.3.9",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0,<3; python_version >= '3.9'",
+  "opencv-python >= 4.1.1"
+]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]

--- a/node-hub/opencv-video-capture/pyproject.toml
+++ b/node-hub/opencv-video-capture/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
   "dora-rs >= 0.3.9",
   "numpy>=1.24.4,<2; python_version == '3.8'",
-  "numpy>=2.0.0,<3; python_version >= '3.9'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "opencv-python >= 4.1.1"
 ]
 


### PR DESCRIPTION
Following the pattern validated in #34 (dora-yolo), this PR updates NumPy version constraints
for several vision and perception node-hub packages:

- dora-internvl
- dora-pyorbbecksdk
- dora-qwen2-5-vl
- dora-pyrealsense
- opencv-plot
- opencv-video-capture

Each package now uses conditional NumPy dependencies based on Python version:
- numpy>=1.24.4,<2 for Python 3.8
- numpy>=2.0.0,<3 for Python >= 3.9

This keeps the changes reviewable, CI-friendly, and consistent across packages.
Refs [#1123](https://github.com/dora-rs/dora/issues/1123).