### PR TITLE
fix(node-hub): relax numpy version constraints for audio-related nodes

### DIFF
--- a/node-hub/dora-distil-whisper/pyproject.toml
+++ b/node-hub/dora-distil-whisper/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.9"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "pyarrow >= 5.0.0",
   "transformers >= 4.0.0",
   "accelerate >= 0.29.2",

--- a/node-hub/dora-echo/pyproject.toml
+++ b/node-hub/dora-echo/pyproject.toml
@@ -10,7 +10,12 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["dora-rs >= 0.3.9", "numpy < 2.0.0", "pyarrow >= 5.0.0"]
+dependencies = [
+   "dora-rs >= 0.3.9",
+   "numpy>=1.24.4,<2; python_version == '3.8'",
+   "numpy>=2.0.0; python_version >= '3.9'",
+   "pyarrow >= 5.0.0"
+]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]

--- a/node-hub/dora-microphone/pyproject.toml
+++ b/node-hub/dora-microphone/pyproject.toml
@@ -12,10 +12,10 @@ requires-python = ">=3.8"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "pyarrow >= 5.0.0",
   "sounddevice >= 0.4.6",
-
 ]
 
 [dependency-groups]

--- a/node-hub/dora-outtetts/pyproject.toml
+++ b/node-hub/dora-outtetts/pyproject.toml
@@ -5,7 +5,7 @@ authors = []
 description = "dora-outtetts"
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.10"
 
 dependencies = [
   "dora-rs >= 0.3.9",

--- a/node-hub/dora-outtetts/pyproject.toml
+++ b/node-hub/dora-outtetts/pyproject.toml
@@ -5,7 +5,7 @@ authors = []
 description = "dora-outtetts"
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8,<3.10"
 
 dependencies = [
   "dora-rs >= 0.3.9",

--- a/node-hub/dora-outtetts/pyproject.toml
+++ b/node-hub/dora-outtetts/pyproject.toml
@@ -9,7 +9,8 @@ requires-python = ">=3.10"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "pyarrow >= 5.0.0",
   "outetts >= 0.2.3",
   "llama-cpp-python>=0.2.0",

--- a/node-hub/dora-parler/pyproject.toml
+++ b/node-hub/dora-parler/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.8"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "sentencepiece >= 0.1.99",
   "pyaudio >= 0.2.14",
   "modelscope >= 1.18.1",

--- a/node-hub/dora-piper/pyproject.toml
+++ b/node-hub/dora-piper/pyproject.toml
@@ -7,7 +7,12 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["dora-rs >= 0.3.9", "piper_sdk >= 0.0.8", "numpy < 2.0.0"]
+dependencies = [
+    "dora-rs >= 0.3.9",
+    "piper_sdk >= 0.0.8",
+    "numpy>=1.24.4,<2; python_version == '3.8'",
+    "numpy>=2.0.0; python_version >= '3.9'",
+]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]

--- a/node-hub/dora-vad/pyproject.toml
+++ b/node-hub/dora-vad/pyproject.toml
@@ -7,7 +7,12 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["dora-rs >= 0.3.9", "numpy < 2.0.0", "silero-vad >= 5.1"]
+dependencies = [
+  "dora-rs >= 0.3.9",
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
+  "silero-vad >= 5.1"
+]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]


### PR DESCRIPTION
Following the pattern validated in [#34 (dora-yolo)](https://github.com/dora-rs/dora-hub/pull/34), this PR updates NumPy version constraints
for several audio and speech-related node-hub packages:

- `dora-distil-whisper`
- `dora-echo`
- `dora-microphone`
- `dora-outtetts`
- `dora-parler`
- `dora-piper`
- `dora-vad`

Each package now uses conditional NumPy dependencies based on Python version:

- `numpy>=1.24.4,<2` for Python 3.8  
- `numpy>=2.0.0` for Python ≥ 3.9

This keeps the changes reviewable, CI-friendly, and consistent across packages.

Refs [#1123](https://github.com/dora-rs/dora/issues/1123).
