### PR TITLE
fix(node-hub): relax numpy version constraints for openai-server and video-encoder package

### DIFF
--- a/node-hub/dora-openai-server/pyproject.toml
+++ b/node-hub/dora-openai-server/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.8"
 
 dependencies = [
   "dora-rs >= 0.3.9",
-  "numpy < 2.0.0",
+ "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "pyarrow >= 5.0.0",
 
   "fastapi >= 0.115",

--- a/node-hub/video-encoder/pyproject.toml
+++ b/node-hub/video-encoder/pyproject.toml
@@ -9,7 +9,8 @@ requires-python = ">=3.9"
 
 dependencies = [
   "dora-rs == 0.3.5",
-  "numpy <=  2.0.0",
+ "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
   "opencv-python >=  4.1.1",
   "python-ffmpeg ~= 2.0.12",
 ]


### PR DESCRIPTION
Following the pattern validated in #34 (dora-yolo), this PR updates NumPy version constraints for additional node-hub packages:

dora-openai-server,
video-encoder

Each package now uses conditional NumPy dependencies based on Python version:
numpy>=1.24.4,<2 for Python 3.8
numpy>=2.0.0,<3 for Python >= 3.9

This keeps the migration incremental, reviewable, and consistent across node-hub packages.
Refs [#1123](https://github.com/dora-rs/dora/issues/1123).