### PR TITLE
feat(node-hub): add generic zero-copy ONNX inference node

### DIFF
--- a/node-hub/dora-onnx/README.md
+++ b/node-hub/dora-onnx/README.md
@@ -1,0 +1,79 @@
+# Dora Node for Generic ONNX Inference
+
+This node loads an exported `.onnx` model, accepts image tensors from the dataflow, performs inference using ONNX Runtime, and outputs the raw result tensors. It automatically tries GPU acceleration (CUDA) and falls back to CPU.
+
+## YAML
+
+```yaml
+- id: onnx-inference
+  build: pip install ../../node-hub/dora-onnx
+  path: dora-onnx
+  inputs:
+    image: webcam/image
+  outputs:
+    - tensor
+  env:
+    MODEL: model.onnx
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--name` | `str` | `onnx-inference` | The name of the node in the dataflow. |
+| `--model` | `str` | `model.onnx` | Path to the `.onnx` model file. |
+| `MODEL` (env) | `str` | — | Environment variable override for the model path (takes priority over `--model`). |
+
+## Inputs
+
+- **`image`**: Arrow `UInt8Array` containing the raw image pixels.
+
+The following metadata fields are required:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `width` | `int` | Image width in pixels. |
+| `height` | `int` | Image height in pixels. |
+| `encoding` | `str` | Pixel format: `rgb8` or `bgr8`. |
+
+```python
+import pyarrow as pa
+
+node.send_output(
+    "image",
+    pa.array(img.ravel()),
+    {"width": 640, "height": 480, "encoding": "rgb8"},
+)
+```
+
+### Preprocessing
+
+The node automatically applies the following preprocessing steps:
+
+1. Reshape to `(H, W, 3)` and convert BGR→RGB if needed.
+2. Transpose to NCHW layout `(1, 3, H, W)`.
+3. Cast to `float32` and normalize to `[0, 1]`.
+
+## Outputs
+
+- **`tensor`**: Arrow array containing the flattened raw output tensor from the model.
+
+Output metadata includes the original input metadata plus:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `shape` | `list[int]` | Original shape of the output tensor (e.g. `[1, 1000]`). |
+| `type` | `str` | Always `"onnx_tensor"`. |
+
+```python
+# Decoding the output tensor
+storage = event["value"]
+metadata = event["metadata"]
+shape = metadata["shape"]
+
+output_tensor = storage.to_numpy().reshape(shape)
+```
+
+## License
+
+This project is licensed under Apache-2.0. Check out [NOTICE.md](../../NOTICE.md) for more information.

--- a/node-hub/dora-onnx/dora_onnx/__init__.py
+++ b/node-hub/dora-onnx/dora_onnx/__init__.py
@@ -1,0 +1,13 @@
+"""TODO: Add docstring."""
+
+import os
+
+# Define the path to the README file relative to the package directory
+readme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+
+# Read the content of the README file
+try:
+    with open(readme_path, encoding="utf-8") as f:
+        __doc__ = f.read()
+except FileNotFoundError:
+    __doc__ = "README file not found."

--- a/node-hub/dora-onnx/dora_onnx/main.py
+++ b/node-hub/dora-onnx/dora_onnx/main.py
@@ -1,0 +1,112 @@
+"""
+Generic ONNX Inference Node for dora-rs.
+This node loads an exported .onnx model, accepts image tensors from the dataflow,
+performs zero-copy inference, and outputs the raw result tensors.
+"""
+
+import argparse
+import os
+
+import numpy as np
+import pyarrow as pa
+from dora import Node
+import onnxruntime as ort
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ONNX Inference Node: Perform high-performance inference using generic ONNX models.",
+    )
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        required=False,
+        help="The name of the node in the dataflow.",
+        default="onnx-inference",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=False,
+        help="The name of the .onnx model file.",
+        default="model.onnx",
+    )
+
+    args = parser.parse_args()
+
+    model_path = os.getenv("MODEL", args.model)
+    
+    # Initialize ONNX Runtime session (tries GPU first, falls back to CPU)
+    providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    print(f"Loading ONNX model from {model_path}...")
+    session = ort.InferenceSession(model_path, providers=providers)
+    
+    # Dynamically get input name expected by the model
+    input_name = session.get_inputs()[0].name
+
+    node = Node(args.name)
+    print(f"ONNX Node '{args.name}' initialized and waiting for inputs...")
+
+    for event in node:
+        event_type = event["type"]
+
+        if event_type == "INPUT":
+            event_id = event["id"]
+
+            if event_id == "image":
+                storage = event["value"]
+                metadata = event["metadata"]
+                encoding = metadata.get("encoding", "rgb8")
+                width = metadata["width"]
+                height = metadata["height"]
+
+                # 1. Zero-copy extraction from PyArrow to NumPy
+                if encoding in ["bgr8", "rgb8"]:
+                    channels = 3
+                    storage_type = np.uint8
+                else:
+                    raise RuntimeError(f"Unsupported image encoding: {encoding}")
+
+                frame = (
+                    storage.to_numpy()
+                    .astype(storage_type)
+                    .reshape((height, width, channels))
+                )
+                
+                if encoding == "bgr8":
+                    frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
+
+                # 2. Preprocess for generic ONNX (HWC to NCHW, uint8 to float32)
+                # Most computer vision ONNX models expect shape [batch, channels, height, width]
+                frame_chw = np.transpose(frame, (2, 0, 1))
+                input_tensor = np.expand_dims(frame_chw, axis=0).astype(np.float32)
+                
+                # Optional standard normalization (0-1) - typically required by AI models
+                input_tensor = input_tensor / 255.0 
+
+                # 3. Perform Inference
+                results = session.run(None, {input_name: input_tensor})
+
+                # 4. Pack the raw output tensor back into PyArrow
+                output_array = results[0]
+                
+                # Flatten the array for easy PyArrow transmission, but keep original shape in metadata
+                out_pa = pa.array(output_array.ravel())
+                
+                out_metadata = event["metadata"]
+                out_metadata["shape"] = list(output_array.shape)
+                out_metadata["type"] = "onnx_tensor"
+
+                # Send output back to the dataflow
+                node.send_output(
+                    "tensor",
+                    out_pa,
+                    out_metadata,
+                )
+
+        elif event_type == "ERROR":
+            print(f"Received dora error: {event['error']}")
+
+if __name__ == "__main__":
+    main()

--- a/node-hub/dora-onnx/dora_onnx/main.py
+++ b/node-hub/dora-onnx/dora_onnx/main.py
@@ -1,111 +1,82 @@
 """
 Generic ONNX Inference Node for dora-rs.
-This node loads an exported .onnx model, accepts image tensors from the dataflow,
-performs zero-copy inference, and outputs the raw result tensors.
 """
-
 import argparse
 import os
-
 import numpy as np
 import pyarrow as pa
 from dora import Node
 import onnxruntime as ort
 
+def preprocess_image(storage: pa.Array, width: int, height: int, encoding: str) -> np.ndarray:
+    """Extracts PyArrow array and converts it to NCHW float32 tensor."""
+    if encoding in ["bgr8", "rgb8"]:
+        channels = 3
+        storage_type = np.uint8
+    else:
+        raise RuntimeError(f"Unsupported image encoding: {encoding}")
+        
+    # 1. Zero-copy extraction to NumPy
+    frame = (
+        storage.to_numpy()
+        .astype(storage_type)
+        .reshape((height, width, channels))
+    )
+    
+    if encoding == "bgr8":
+        frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
+        
+    # 2. Preprocess for generic ONNX (HWC to NCHW)
+    frame_chw = np.transpose(frame, (2, 0, 1))
+    input_tensor = np.expand_dims(frame_chw, axis=0).astype(np.float32)
+    
+    # Normalization (0-1)
+    input_tensor = input_tensor / 255.0 
+    
+    return input_tensor
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="ONNX Inference Node: Perform high-performance inference using generic ONNX models.",
-    )
-
-    parser.add_argument(
-        "--name",
-        type=str,
-        required=False,
-        help="The name of the node in the dataflow.",
-        default="onnx-inference",
-    )
-    parser.add_argument(
-        "--model",
-        type=str,
-        required=False,
-        help="The name of the .onnx model file.",
-        default="model.onnx",
-    )
-
+    parser = argparse.ArgumentParser(description="ONNX Inference Node")
+    parser.add_argument("--name", type=str, default="onnx-inference")
+    parser.add_argument("--model", type=str, default="model.onnx")
     args = parser.parse_args()
-
-    model_path = os.getenv("MODEL", args.model)
     
-    # Initialize ONNX Runtime session (tries GPU first, falls back to CPU)
+    model_path = os.getenv("MODEL", args.model)
     providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
     print(f"Loading ONNX model from {model_path}...")
     session = ort.InferenceSession(model_path, providers=providers)
-    
-    # Dynamically get input name expected by the model
     input_name = session.get_inputs()[0].name
-
+    
     node = Node(args.name)
     print(f"ONNX Node '{args.name}' initialized and waiting for inputs...")
-
+    
     for event in node:
-        event_type = event["type"]
-
-        if event_type == "INPUT":
-            event_id = event["id"]
-
-            if event_id == "image":
-                storage = event["value"]
-                metadata = event["metadata"]
-                encoding = metadata.get("encoding", "rgb8")
-                width = metadata["width"]
-                height = metadata["height"]
-
-                # 1. Zero-copy extraction from PyArrow to NumPy
-                if encoding in ["bgr8", "rgb8"]:
-                    channels = 3
-                    storage_type = np.uint8
-                else:
-                    raise RuntimeError(f"Unsupported image encoding: {encoding}")
-
-                frame = (
-                    storage.to_numpy()
-                    .astype(storage_type)
-                    .reshape((height, width, channels))
-                )
-                
-                if encoding == "bgr8":
-                    frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
-
-                # 2. Preprocess for generic ONNX (HWC to NCHW, uint8 to float32)
-                # Most computer vision ONNX models expect shape [batch, channels, height, width]
-                frame_chw = np.transpose(frame, (2, 0, 1))
-                input_tensor = np.expand_dims(frame_chw, axis=0).astype(np.float32)
-                
-                # Optional standard normalization (0-1) - typically required by AI models
-                input_tensor = input_tensor / 255.0 
-
-                # 3. Perform Inference
-                results = session.run(None, {input_name: input_tensor})
-
-                # 4. Pack the raw output tensor back into PyArrow
-                output_array = results[0]
-                
-                # Flatten the array for easy PyArrow transmission, but keep original shape in metadata
-                out_pa = pa.array(output_array.ravel())
-                
-                out_metadata = event["metadata"]
-                out_metadata["shape"] = list(output_array.shape)
-                out_metadata["type"] = "onnx_tensor"
-
-                # Send output back to the dataflow
-                node.send_output(
-                    "tensor",
-                    out_pa,
-                    out_metadata,
-                )
-
-        elif event_type == "ERROR":
+        if event["type"] == "INPUT" and event["id"] == "image":
+            storage = event["value"]
+            metadata = event["metadata"]
+            
+            # Use the extracted function
+            input_tensor = preprocess_image(
+                storage=storage, 
+                width=metadata["width"], 
+                height=metadata["height"], 
+                encoding=metadata.get("encoding", "rgb8")
+            )
+            
+            # 3. Perform Inference
+            results = session.run(None, {input_name: input_tensor})
+            
+            # 4. Pack output
+            output_array = results[0]
+            out_pa = pa.array(output_array.ravel())
+            
+            out_metadata = event["metadata"]
+            out_metadata["shape"] = list(output_array.shape)
+            out_metadata["type"] = "onnx_tensor"
+            
+            node.send_output("tensor", out_pa, out_metadata)
+            
+        elif event["type"] == "ERROR":
             print(f"Received dora error: {event['error']}")
 
 if __name__ == "__main__":

--- a/node-hub/dora-onnx/pyproject.toml
+++ b/node-hub/dora-onnx/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "dora-onnx"
+version = "0.0.1"
+authors = [
+  { name = "Leonardo Galgano", email = "leo.gal.03@gmail.com" },
+]
+description = "Generic ONNX inference node for dora-rs"
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.8"
+
+dependencies = [
+  "dora-rs >= 0.3.9", 
+  "numpy>=1.24.4,<2; python_version == '3.8'",
+  "numpy>=2.0.0; python_version >= '3.9'",
+  "onnxruntime >= 1.18.0"
+]
+
+[dependency-groups]
+dev = ["pytest >=8.1.1", "ruff >=0.9.1"]
+
+[project.scripts]
+dora-onnx = "dora_onnx.main:main"
+
+[tool.ruff.lint]
+extend-select = [
+  "D",    # pydocstyle
+  "UP",   # Ruff's UP rule
+  "PERF", # Ruff's PERF rule
+  "RET",  # Ruff's RET rule
+  "RSE",  # Ruff's RSE rule
+  "NPY",  # Ruff's NPY rule
+  "N",    # Ruff's N rule
+  "I",    # Ruff's I rule
+]

--- a/node-hub/dora-onnx/tests/test_onnx.py
+++ b/node-hub/dora-onnx/tests/test_onnx.py
@@ -1,12 +1,30 @@
 """Tests for the dora-onnx inference node."""
-
 import pytest
+import numpy as np
+import pyarrow as pa
+from dora_onnx.main import preprocess_image
 
+def test_preprocess_rgb8():
+    """Test that a raw rgb8 PyArrow array is correctly converted to NCHW tensor."""
+    width, height = 640, 480
+    channels = 3
+    
+    # Create a dummy image (HWC layout) with random uint8 pixels
+    dummy_image = np.random.randint(0, 255, size=(height, width, channels), dtype=np.uint8)
+    
+    # Flatten it into a PyArrow array (simulating Dora dataflow memory)
+    pa_storage = pa.array(dummy_image.ravel())
+    
+    # Run our preprocessing function
+    tensor = preprocess_image(pa_storage, width, height, "rgb8")
+    
+    # Assertions
+    assert tensor.shape == (1, 3, height, width), "Tensor must be in NCHW format"
+    assert tensor.dtype == np.float32, "Tensor must be cast to float32"
+    assert np.max(tensor) <= 1.0, "Tensor must be normalized between 0 and 1"
 
-def test_import_main():
-    """Test that the main module can be imported."""
-    from dora_onnx.main import main
-
-    # Check that everything is working, and catch dora Runtime Exception as we're not running in a dora dataflow.
-    with pytest.raises(RuntimeError):
-        main()
+def test_preprocess_unsupported_encoding():
+    """Test that unsupported encodings raise a clear error."""
+    pa_storage = pa.array([0, 1, 2])
+    with pytest.raises(RuntimeError, match="Unsupported image encoding"):
+        preprocess_image(pa_storage, 10, 10, "nv12")

--- a/node-hub/dora-onnx/tests/test_onnx.py
+++ b/node-hub/dora-onnx/tests/test_onnx.py
@@ -1,0 +1,12 @@
+"""Tests for the dora-onnx inference node."""
+
+import pytest
+
+
+def test_import_main():
+    """Test that the main module can be imported."""
+    from dora_onnx.main import main
+
+    # Check that everything is working, and catch dora Runtime Exception as we're not running in a dora dataflow.
+    with pytest.raises(RuntimeError):
+        main()


### PR DESCRIPTION
## Description

This PR adds `dora-onnx`, a generic ONNX Runtime inference node for Dora dataflows.

While exploring the repository for **GSoC 2026 Project #1 (Theme 3: AI Developer Experience)**, I noticed there wasn't a dedicated, model-agnostic ONNX node. This node lets you load any exported `.onnx` model, read zero-copy image tensors from the Dora memory pool via Apache Arrow, and get back raw output tensors with shape metadata preserved.

### What the node does:

* Extracts PyArrow arrays directly into NumPy without copying, reshaping dynamically based on incoming metadata.
* Initializes `onnxruntime` with both `CUDAExecutionProvider` and `CPUExecutionProvider`, so it runs on GPU or CPU without code changes.
* Flattens the N-dimensional output tensor for PyArrow transmission and stores the original shape in the event metadata so downstream nodes can reconstruct it.
* `pyproject.toml` handles `numpy>=2.0.0` for Python >= 3.9, matching recent ecosystem upgrades.

### Testing

- [x] Node successfully initializes `onnxruntime.InferenceSession`.
- [x] `argparse` CLI is exposed correctly.

I started this as a GSoC exploration for Theme 3 (AI tooling) and plan to keep building on it. Looking forward to feedback on the architecture!