### PR TITLE
fix(dora-teleop-xr): resolve Ruff docstring and naming violations

### DIFF
--- a/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
+++ b/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
@@ -48,6 +48,7 @@ class JointNamesProvider(Protocol):
 
 class IKStateContainer(TypedDict):
     """Shared IK state container used between threads."""
+
     q: NDArray[np.float32]
     active: bool
     xr_state: XRState | None
@@ -189,7 +190,6 @@ def reorder_joint_state_for_rerun(
 
 def main():
     """Entry point for the dora-teleop-xr node."""
-    
     jax.config.update("jax_platform_name", "cpu")
 
     robot_class_path = os.environ.get(

--- a/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
+++ b/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
@@ -20,6 +20,7 @@ from teleop_xr.messages import XRState
 
 
 def load_robot_class(class_path: str):
+    """Load and return a robot class from a 'module:ClassName' string."""
     if ":" not in class_path:
         raise ValueError(
             f"Invalid ROBOT_CLASS format: '{class_path}'. Expected 'module:ClassName'"
@@ -30,23 +31,31 @@ def load_robot_class(class_path: str):
 
 
 def get_robot_joint_order(robot_class) -> tuple[str, ...] | None:
+    """Return the default joint order for rerun if defined on the robot class."""
     if hasattr(robot_class, "DEFAULT_RERUN_JOINT_ORDER"):
         return robot_class.DEFAULT_RERUN_JOINT_ORDER
     return None
 
 
 class JointNamesProvider(Protocol):
+    """Protocol defining access to actuated joint names."""
+
     @property
-    def actuated_joint_names(self) -> list[str]: ...
+    def actuated_joint_names(self) -> list[str]:
+        """Return the list of actuated joint names."""
+        ...
 
 
 class IKStateContainer(TypedDict):
+    """Shared IK state container used between threads."""
     q: NDArray[np.float32]
     active: bool
     xr_state: XRState | None
 
 
 class IKWorker(threading.Thread):
+    """Background worker handling IK computation and teleop updates."""
+
     def __init__(
         self,
         controller: IKController,
@@ -54,6 +63,7 @@ class IKWorker(threading.Thread):
         teleop: Teleop,
         state_container: IKStateContainer,
     ):
+        """Initialize IK worker with controller, robot, and teleop context."""
         super().__init__(daemon=True)
         self.controller = controller
         self.robot = robot
@@ -65,10 +75,12 @@ class IKWorker(threading.Thread):
         self.teleop_loop = None
 
     def update_state(self, state: XRState):
+        """Update the latest XR state and notify the worker loop."""
         self.latest_xr_state = state
         self.new_state_event.set()
 
     def set_teleop_loop(self, loop: asyncio.AbstractEventLoop):
+        """Attach the running teleop event loop for async publishing."""
         if self.teleop_loop is None:
             self.teleop_loop = loop
             if "q" in self.state_container:
@@ -84,6 +96,7 @@ class IKWorker(threading.Thread):
                 )
 
     def run(self):
+        """Continuously process XR state updates and compute IK solutions."""
         while self.running:
             if not self.new_state_event.wait(timeout=0.1):
                 continue
@@ -128,6 +141,7 @@ class IKWorker(threading.Thread):
 
 
 def pose_to_array(pose):
+    """Convert a pose object into a float32 numpy array (xyz + quaternion)."""
     if not pose or not pose.position or not pose.orientation:
         return None
     pos = pose.position
@@ -151,6 +165,7 @@ def reorder_joint_state_for_rerun(
     q_current: NDArray[np.float32],
     joint_order: tuple[str, ...] | None,
 ) -> NDArray[np.float32]:
+    """Reorder joint state to match a target joint order if compatible."""
     if joint_order is None:
         return q_current
 
@@ -173,6 +188,8 @@ def reorder_joint_state_for_rerun(
 
 
 def main():
+    """Entry point for the dora-teleop-xr node."""
+    
     jax.config.update("jax_platform_name", "cpu")
 
     robot_class_path = os.environ.get(

--- a/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
+++ b/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
@@ -41,7 +41,7 @@ def test_so101_robot_init():
 
 def test_reorder_joint_state_for_rerun_so101_order():
     """Test joint state reordering for SO101 URDF traversal order."""
-    SO101_ORDER = (
+    so101_order  = (
         "shoulder_pan",
         "shoulder_lift",
         "elbow_flex",
@@ -59,7 +59,7 @@ def test_reorder_joint_state_for_rerun_so101_order():
         ]
 
     q_current = np.array([1, 2, 3, 4, 5], dtype=np.float32)
-    reordered = reorder_joint_state_for_rerun(MockRobot(), q_current, SO101_ORDER)
+    reordered = reorder_joint_state_for_rerun(MockRobot(), q_current, so101_order )
 
     expected = np.array([5, 4, 3, 2, 1], dtype=np.float32)
     assert np.allclose(reordered, expected)

--- a/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
+++ b/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
@@ -7,7 +7,6 @@ from dora_teleop_xr.main import pose_to_array, reorder_joint_state_for_rerun
 
 def test_pose_to_array():
     """Test pose_to_array function."""
-
     class MockPose:
         """Mock pose object."""
 
@@ -41,7 +40,7 @@ def test_so101_robot_init():
 
 def test_reorder_joint_state_for_rerun_so101_order():
     """Test joint state reordering for SO101 URDF traversal order."""
-    so101_order  = (
+    so101_order = (
         "shoulder_pan",
         "shoulder_lift",
         "elbow_flex",
@@ -67,7 +66,6 @@ def test_reorder_joint_state_for_rerun_so101_order():
 
 def test_reorder_joint_state_for_rerun_unknown_names_keeps_input():
     """Test unknown joint names are passed through unchanged."""
-
     class MockRobot:
         actuated_joint_names = ["joint_a", "joint_b"]
 


### PR DESCRIPTION
## Fix Ruff lint issues in dora-teleop-xr

This PR resolves Ruff lint failures in `dora-teleop-xr` by:

- Adding minimal docstrings to public functions, classes, and methods
- Renaming a test variable to satisfy naming rules (N806)

No functional changes — tests and behavior remain the same.