### PR TITLE
fix(dora-sam2): resolve SAM2 prompt labels bug causing background segmentation

### DIFF
--- a/node-hub/dora-sam2/dora_sam2/main.py
+++ b/node-hub/dora-sam2/dora_sam2/main.py
@@ -214,7 +214,7 @@ def main():
                     ),
                 ):
                     predictor.set_image(frames[image_id])
-                    labels = [i for i in range(len(points))]
+                    labels = [1 for i in range(len(points))]
                     masks, _scores, last_pred = predictor.predict(
                         points,
                         point_labels=labels,


### PR DESCRIPTION
This PR fixes a bug in the `dora-sam2` node where point prompts were being incorrectly classified as background points.

In the original implementation, `point_labels` were generated using a loop index `[i for i in range(len(points))]`. This resulted in the first clicked coordinate receiving a label of `0` (background), causing SAM 2 to actively segment away from the intended target. 

**Key Changes:**
* Updated the point labels generation to default to `1` (foreground) for standard point prompts.

**Testing:**
* [x] Verified locally using `dora` dataflow with OpenCV click events.