### PR TITLE
fix: enable tokio `macros` and `rt-multi-thread` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,4 @@ path = "examples/rerun-viewer/run.rs"
 [dependencies]
 eyre = "0.6.8"
 sha1 = "0.10.6"
+tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Adds missing tokio feature flags to resolve `#[tokio::main]` macro failures across examples (benchmark, camera, vlm, rerun-viewer, python-dataflow, python-operator-dataflow).