### PR TITLE
opencv_video_capture: fix test

### DIFF
--- a/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
+++ b/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
@@ -1,10 +1,20 @@
-"""TODO: Add docstring."""
+"""Tests for opencv_video_capture.main."""
+
+import sys
+from unittest.mock import patch
 
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def clear_argv():
+    """Prevent argparse from picking up pytest's own command-line arguments."""
+    with patch.object(sys, "argv", ["opencv-video-capture"]):
+        yield
+
+
 def test_import_main():
-    """TODO: Add docstring."""
+    """Node entrypoint is importable."""
     from opencv_video_capture.main import main
 
     # Check that everything is working, and catch dora Runtime Exception as we're not running in a dora dataflow.


### PR DESCRIPTION
Fixed the following error that occurred when running the tests:

```
self = ArgumentParser(prog='pytest', usage=None, description='OpenCV Video Capture: This node is used to capture video from a camera.', formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=True)
status = 2, message = 'pytest: error: unrecognized arguments: tests/ -v\n'

    def exit(self, status=0, message=None):
        if message:
            self._print_message(message, _sys.stderr)
>       _sys.exit(status)
E       SystemExit: 2
```