### PR TITLE
opencv-video-capture: release the capture resource

### DIFF
--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -361,6 +361,8 @@ def main():
         elif event_type == "ERROR":
             raise RuntimeError(event["error"])
 
+    video_capture.release()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The documentation also mentions that it should be released.
https://docs.opencv.org/4.13.0/dd/d43/tutorial_py_video_display.html