### PR TITLE
Set camera capture FPS through environment variable

### DIFF
--- a/node-hub/opencv-video-capture/README.md
+++ b/node-hub/opencv-video-capture/README.md
@@ -39,10 +39,6 @@ This node is used to capture video from a camera using OpenCV.
 
 - A warning is printed at startup if the camera negotiates a frame rate
   different from `CAPTURE_FPS`.
-- The camera only delivers the requested rate if the selected
-  resolution/pixel format supports it. Check supported modes with
-  `v4l2-ctl --list-formats-ext` (Linux) or
-  `ffmpeg -f avfoundation -framerate 1000 -i <index>` (macOS).
 - In low light, cameras with auto-exposure may halve the frame rate.
 
 # Inputs

--- a/node-hub/opencv-video-capture/README.md
+++ b/node-hub/opencv-video-capture/README.md
@@ -44,10 +44,6 @@ This node is used to capture video from a camera using OpenCV.
   `v4l2-ctl --list-formats-ext` (Linux) or
   `ffmpeg -f avfoundation -framerate 1000 -i <index>` (macOS).
 - In low light, cameras with auto-exposure may halve the frame rate.
-- macOS limitation: OpenCV's AVFoundation backend can only adjust the
-  frame rate within the camera's default format, which usually tops out
-  at 30 fps. High-fps modes (e.g. 60 fps on an iPhone Continuity Camera)
-  cannot be enabled through OpenCV, even though ffmpeg can use them.
 
 # Inputs
 

--- a/node-hub/opencv-video-capture/README.md
+++ b/node-hub/opencv-video-capture/README.md
@@ -9,7 +9,7 @@ This node is used to capture video from a camera using OpenCV.
   build: pip install ../../opencv-video-capture
   path: opencv-video-capture
   inputs:
-    tick: dora/timer/millis/16 # try to capture at 60fps
+    tick: dora/timer/millis/16 # how often to read a frame (~60Hz)
   outputs:
     - image: # the captured image
 
@@ -19,10 +19,35 @@ This node is used to capture video from a camera using OpenCV.
     IMAGE_WIDTH: 640 # optional, default is video capture width
     IMAGE_HEIGHT: 480 # optional, default is video capture height
 
+    # optional, default is the camera default (often 30 fps).
+    # The tick input only controls how often frames are READ; the actual
+    # capture rate is negotiated with the camera. To capture at 60 fps you
+    # must both set CAPTURE_FPS: 60 and use a tick of at most ~16ms.
+    CAPTURE_FPS: 60
+
+    # optional, default is the camera default.
+    # On Linux UVC cameras, MJPG is often required to reach high frame
+    # rates (e.g. 60 fps at 720p or above) due to USB bandwidth limits.
+    CAPTURE_FOURCC: MJPG
+
     # optional, default is 95.
     # This is used only when encoding is one of "jpeg", "jpg" or "jpe".
     JPEG_QUALITY: 95
 ```
+
+## Frame rate notes
+
+- A warning is printed at startup if the camera negotiates a frame rate
+  different from `CAPTURE_FPS`.
+- The camera only delivers the requested rate if the selected
+  resolution/pixel format supports it. Check supported modes with
+  `v4l2-ctl --list-formats-ext` (Linux) or
+  `ffmpeg -f avfoundation -framerate 1000 -i <index>` (macOS).
+- In low light, cameras with auto-exposure may halve the frame rate.
+- macOS limitation: OpenCV's AVFoundation backend can only adjust the
+  frame rate within the camera's default format, which usually tops out
+  at 30 fps. High-fps modes (e.g. 60 fps on an iPhone Continuity Camera)
+  cannot be enabled through OpenCV, even though ffmpeg can use them.
 
 # Inputs
 

--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -188,7 +188,7 @@ def main():
     )
     parser.add_argument(
         "--capture-fps",
-        type=int,
+        type=float,
         required=False,
         help=(
             "The frame rate to request from the camera. Default is the "
@@ -299,13 +299,14 @@ def main():
     # negotiated with the camera here.
     capture_fps = os.getenv("CAPTURE_FPS", args.capture_fps)
     if capture_fps is not None:
-        if isinstance(capture_fps, str) and capture_fps.isnumeric():
-            capture_fps = int(capture_fps)
+        # OpenCV's FPS property is a double; fractional rates such as
+        # 29.97 or 59.94 are common camera modes.
+        capture_fps = float(capture_fps)
         video_capture.set(cv2.CAP_PROP_FPS, capture_fps)
         actual_fps = video_capture.get(cv2.CAP_PROP_FPS)
         if actual_fps > 0 and abs(actual_fps - capture_fps) > 1:
             print(
-                f"Warning: requested CAPTURE_FPS={capture_fps} but the camera "
+                f"Warning: requested CAPTURE_FPS={capture_fps:g} but the camera "
                 f"negotiated {actual_fps:g} fps. The output rate is limited "
                 f"by the camera, not by the tick rate. On Linux UVC cameras, "
                 f"try CAPTURE_FOURCC=MJPG and/or a lower resolution. On "

--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -187,6 +187,27 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--capture-fps",
+        type=int,
+        required=False,
+        help=(
+            "The frame rate to request from the camera. Default is the "
+            "camera default (often 30 fps)."
+        ),
+        default=None,
+    )
+    parser.add_argument(
+        "--capture-fourcc",
+        type=str,
+        required=False,
+        help=(
+            "The FOURCC pixel format to request from the camera (e.g. MJPG). "
+            "On Linux UVC cameras, MJPG is often required for high frame "
+            "rates. Default is the camera default."
+        ),
+        default=None,
+    )
+    parser.add_argument(
         "--jpeg-quality",
         type=int,
         required=False,
@@ -251,6 +272,14 @@ def main():
         else:
             print(f"Opened camera at index {video_capture_path}")
 
+    # Set the pixel format first: on Linux (V4L2), the FOURCC must be set
+    # before the resolution and frame rate for the camera to honor it.
+    capture_fourcc = os.getenv("CAPTURE_FOURCC", args.capture_fourcc)
+    if capture_fourcc:
+        video_capture.set(
+            cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*capture_fourcc)
+        )
+
     image_width = os.getenv("IMAGE_WIDTH", args.image_width)
 
     if image_width is not None:
@@ -263,6 +292,26 @@ def main():
         if isinstance(image_height, str) and image_height.isnumeric():
             image_height = int(image_height)
         video_capture.set(cv2.CAP_PROP_FRAME_HEIGHT, image_height)
+
+    # Set the frame rate last, as the supported rates depend on the
+    # resolution and pixel format chosen above. Note that the tick input
+    # only controls how often frames are read; the actual capture rate is
+    # negotiated with the camera here.
+    capture_fps = os.getenv("CAPTURE_FPS", args.capture_fps)
+    if capture_fps is not None:
+        if isinstance(capture_fps, str) and capture_fps.isnumeric():
+            capture_fps = int(capture_fps)
+        video_capture.set(cv2.CAP_PROP_FPS, capture_fps)
+        actual_fps = video_capture.get(cv2.CAP_PROP_FPS)
+        if actual_fps > 0 and abs(actual_fps - capture_fps) > 1:
+            print(
+                f"Warning: requested CAPTURE_FPS={capture_fps} but the camera "
+                f"negotiated {actual_fps:g} fps. The output rate is limited "
+                f"by the camera, not by the tick rate. On Linux UVC cameras, "
+                f"try CAPTURE_FOURCC=MJPG and/or a lower resolution. On "
+                f"macOS, OpenCV's AVFoundation backend cannot enable "
+                f"high-fps camera modes."
+            )
 
     jpeg_quality = os.getenv("JPEG_QUALITY", args.jpeg_quality)
     if jpeg_quality is not None:

--- a/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
+++ b/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
@@ -101,6 +101,17 @@ def test_capture_fps_sets_cap_prop_fps(monkeypatch):
     mock_cap.set.assert_any_call(cv2.CAP_PROP_FPS, 60)
 
 
+def test_capture_fps_accepts_fractional_rate(monkeypatch):
+    """Fractional rates such as 59.94 must be parsed as float, not crash."""
+    monkeypatch.setenv("CAPTURE_FPS", "59.94")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.get.return_value = 59.94
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    mock_cap.set.assert_any_call(cv2.CAP_PROP_FPS, 59.94)
+
+
 def test_capture_fps_not_set_by_default(monkeypatch):
     """Without CAPTURE_FPS, the camera fps must be left untouched."""
     monkeypatch.delenv("CAPTURE_FPS", raising=False)

--- a/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
+++ b/node-hub/opencv-video-capture/tests/test_opencv_video_capture.py
@@ -3,6 +3,7 @@
 import sys
 from unittest.mock import MagicMock, patch
 
+import cv2
 import numpy as np
 import pytest
 
@@ -87,3 +88,85 @@ def test_input_closed_other_does_not_exit():
     ]
     mock_node = _run_main(events, mock_cap)
     mock_node.send_output.assert_called_once()
+
+
+def test_capture_fps_sets_cap_prop_fps(monkeypatch):
+    """CAPTURE_FPS must be requested from the camera via CAP_PROP_FPS."""
+    monkeypatch.setenv("CAPTURE_FPS", "60")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.get.return_value = 60.0
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    mock_cap.set.assert_any_call(cv2.CAP_PROP_FPS, 60)
+
+
+def test_capture_fps_not_set_by_default(monkeypatch):
+    """Without CAPTURE_FPS, the camera fps must be left untouched."""
+    monkeypatch.delenv("CAPTURE_FPS", raising=False)
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    fps_calls = [
+        c for c in mock_cap.set.call_args_list
+        if c.args and c.args[0] == cv2.CAP_PROP_FPS
+    ]
+    assert not fps_calls
+
+
+def test_capture_fps_warns_when_camera_negotiates_other_fps(monkeypatch, capsys):
+    """A warning must be printed when the camera does not deliver the requested fps."""
+    monkeypatch.setenv("CAPTURE_FPS", "60")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.get.return_value = 30.0
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    out = capsys.readouterr().out
+    assert "Warning" in out
+    assert "60" in out
+    assert "30" in out
+
+
+def test_capture_fps_no_warning_when_fps_matches(monkeypatch, capsys):
+    """No warning must be printed when the camera delivers the requested fps."""
+    monkeypatch.setenv("CAPTURE_FPS", "60")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.get.return_value = 60.0
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    assert "Warning" not in capsys.readouterr().out
+
+
+def test_capture_fourcc_sets_cap_prop_fourcc(monkeypatch):
+    """CAPTURE_FOURCC must be applied to the camera via CAP_PROP_FOURCC."""
+    monkeypatch.setenv("CAPTURE_FOURCC", "MJPG")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    mock_cap.set.assert_any_call(
+        cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG")
+    )
+
+
+def test_capture_property_order_fourcc_resolution_fps(monkeypatch):
+    """Properties must be set as fourcc -> width -> height -> fps (required by V4L2)."""
+    monkeypatch.setenv("CAPTURE_FOURCC", "MJPG")
+    monkeypatch.setenv("IMAGE_WIDTH", "1280")
+    monkeypatch.setenv("IMAGE_HEIGHT", "720")
+    monkeypatch.setenv("CAPTURE_FPS", "60")
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.get.return_value = 60.0
+
+    _run_main([{"type": "STOP"}], mock_cap)
+    props = [c.args[0] for c in mock_cap.set.call_args_list]
+    assert props == [
+        cv2.CAP_PROP_FOURCC,
+        cv2.CAP_PROP_FRAME_WIDTH,
+        cv2.CAP_PROP_FRAME_HEIGHT,
+        cv2.CAP_PROP_FPS,
+    ]


### PR DESCRIPTION
## Summary

This PR adds camera frame-rate configuration support so the capture node can request high-FPS modes from the camera, instead of only controlling how often frames are read from the capture buffer.

Previously, setting `tick: dora/timer/millis/16` only changed the polling interval. The camera itself still captured at its default rate, often 30 FPS, so this alone could not produce true 60 FPS output.

## Changes

* Add `CAPTURE_FPS` / `--capture-fps`

  * Requests a camera frame rate via `CAP_PROP_FPS`.
  * Parsed as `float` to support fractional modes such as `29.97` and `59.94`.
  * If unset, the camera default is left untouched.

* Add `CAPTURE_FOURCC` / `--capture-fourcc`

  * Requests a pixel format via `CAP_PROP_FOURCC`, for example `MJPG`.
  * This is especially useful for Linux UVC cameras, where MJPG is often required to reach 60 FPS at 720p or higher because of USB bandwidth limits.

* Apply camera properties in V4L2-friendly order

  * FOURCC is set first.
  * Width and height are set next.
  * FPS is set last.
  * This ordering is required for some V4L2 cameras to correctly negotiate the requested mode.

## Motivation

The `tick` input controls only how frequently frames are read from the capture buffer. It does not configure the camera’s actual capture rate.

As a result, users could configure a 16 ms timer expecting 60 FPS output, while the camera continued capturing at its default rate, commonly 30 FPS. This PR makes the requested capture rate explicit and configurable.
