### PR TITLE
Hub P2.3 (1/3): bootstrap node-index catalog + index CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/publish-node.md
+++ b/.github/PULL_REQUEST_TEMPLATE/publish-node.md
@@ -1,0 +1,18 @@
+<!--
+Publishing a node to the Dora Hub index. Open this with:
+  ?template=publish-node.md
+or just edit the checklist below. CI validates everything automatically.
+-->
+
+## Publish: `<namespace>/<name>@<version>`
+
+Generated with `dora hub publish` (please don't hand-edit version entries).
+
+### Checklist
+- [ ] Adds **only new** `node-index/<ns>/<name>/<version>.yml` file(s) (published versions are immutable — append-only).
+- [ ] `source.rev` is a full commit hash the source repo actually contains.
+- [ ] `manifest.namespace` / `manifest.name` match the directory path.
+- [ ] I am listed in `node-index/<ns>/<name>/package.yml` `owners` (or this PR also adds the package + my namespace claim).
+
+### Notes
+<!-- Anything reviewers/automation should know. New namespaces and OWNERS changes get a human review. -->

--- a/.github/workflows/node-index-ci.yml
+++ b/.github/workflows/node-index-ci.yml
@@ -1,0 +1,35 @@
+name: node-index CI
+
+# Path-scoped to the catalog: this never runs for, and never gates, the
+# human-reviewed `node-hub/` source path (Hub spec §7.5 / P2.3).
+on:
+  pull_request:
+    paths:
+      - 'node-index/**'
+      - 'schemas/node-index-*.schema.json'
+      - 'scripts/index-ci/**'
+      - '.github/workflows/node-index-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  index-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: pip install jsonschema pyyaml
+      - name: Unit tests (validator + append-only logic)
+        run: python3 scripts/index-ci/tests/test_index_ci.py
+      - name: Validate catalog entries (schema + paths + pins)
+        run: python3 scripts/index-ci/validate_entries.py
+      - name: Fetch base branch
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
+      - name: Append-only enforcement (§7.5)
+        run: python3 scripts/index-ci/check_append_only.py --base "origin/${{ github.base_ref }}"

--- a/node-index/README.md
+++ b/node-index/README.md
@@ -1,0 +1,65 @@
+# `node-index/` — the Dora Hub catalog
+
+This directory is the **Dora Hub index**: a git-backed catalog mapping
+`[<namespace>/]<name>@<version>` to a node's manifest snapshot and a pointer to
+where its source lives. The `dora` CLI resolves `hub:` references against it.
+
+Full design: [`docs/plan-node-hub.md` §7](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md)
+in `dora-rs/dora`.
+
+## Layout
+
+```
+node-index/
+  <namespace>/
+    <name>/
+      package.yml        # description, repo, and the OWNERS list (who may publish)
+      <version>.yml       # one file per published version: manifest + source pointer
+```
+
+A version file is the node's `dora-node.yml` (verbatim) plus a `source` stanza:
+
+```yaml
+# node-index/dora-rs/dora-yolo/0.5.2.yml
+manifest: { ...dora-node.yml contents... }
+source:
+  git: https://github.com/dora-rs/dora-hub   # or the author's own repo
+  rev: 9f4c1ae...                            # a full commit hash (never a branch/tag)
+  subdir: node-hub/dora-yolo                 # where the node lives in the repo
+published: "2026-07-01T12:00:00Z"
+yanked: false
+```
+
+The index **never hosts the bytes** — it points at them. The source repo need
+not be `dora-hub`; third-party namespaces point at their own repos.
+
+## Publishing
+
+Use the CLI rather than hand-editing:
+
+```bash
+dora hub publish            # validates the manifest, resolves the commit pin,
+                            # and prints/opens the index entry to add
+```
+
+Then open a PR adding the `node-index/<ns>/<name>/<version>.yml` file. CI
+validates it and (once the auto-merge bot lands) merges it without a review
+queue — publishing latency is CI latency.
+
+## Rules (machine-enforced by `node-index CI`)
+
+- **Append-only.** A PR may *add* version files. The only permitted edit to an
+  existing version file is flipping `yanked` (with a `yank_reason`) or
+  *appending* late `source.binary` platform entries. Any other change to a
+  published version fails CI — published versions are immutable.
+- **Schema + pins.** Entries validate against
+  [`schemas/node-index-entry.schema.json`](../schemas/node-index-entry.schema.json);
+  `source.rev` must be a full 40-/64-hex commit, and the directory must match
+  `manifest.namespace` / `manifest.name`.
+- **Namespaces.** A new namespace claim (`package.yml`) for a
+  [reserved name](../scripts/index-ci/reserved_namespaces.txt) needs an index
+  admin. Owner-identity and confusable-name checks land with the governance
+  workstream (P2.3 PR 2).
+
+These checks run **only** on `node-index/**` — they never gate the
+human-reviewed `node-hub/` source path.

--- a/node-index/README.md
+++ b/node-index/README.md
@@ -63,3 +63,14 @@ queue — publishing latency is CI latency.
 
 These checks run **only** on `node-index/**` — they never gate the
 human-reviewed `node-hub/` source path.
+
+## Status: not yet a trust boundary
+
+This bootstrap (P2.3 PR 1) lands the schema, path/pin validation, and the
+append-only rule. It does **not** yet verify *who* may publish: the CI proves an
+entry is well-formed and immutable, not that the PR author owns the namespace.
+Until the governance workstream (PR 2) and the auto-merge bot (PR 3) land — the
+bot enforces the `package.yml` OWNERS list and reserved-namespace claims — a
+`node-index/` entry must be treated as *unverified provenance*, not an
+authoritative mapping. Resolving `hub:` references should stay opt-in/manual
+until then.

--- a/schemas/node-index-entry.schema.json
+++ b/schemas/node-index-entry.schema.json
@@ -41,8 +41,8 @@
         },
         "subdir": {
           "type": "string",
-          "description": "Where in the repository the node lives (monorepo support). Forward slashes, relative, no `..`.",
-          "pattern": "^(?!.*\\.\\.)(?!/)[^\\\\]+$"
+          "description": "Where in the repository the node lives (monorepo support). Forward slashes, relative, no `..`, single line.",
+          "pattern": "^(?!/)(?!.*\\.\\.)[^\\\\\\n\\r]+$"
         },
         "binary": {
           "type": "array",

--- a/schemas/node-index-entry.schema.json
+++ b/schemas/node-index-entry.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/dora-rs/dora-hub/schemas/node-index-entry.schema.json",
+  "title": "Dora Hub node-index version entry",
+  "description": "One published version: a manifest snapshot plus a source pointer. Mirrors the `IndexEntry` the dora CLI writes (`dora hub publish`). The manifest is already validated by the CLI at publish time; this schema checks the index envelope structurally.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest", "source"],
+  "properties": {
+    "manifest": {
+      "type": "object",
+      "description": "The node's dora-node.yml, copied verbatim at publish time.",
+      "required": ["apiVersion", "name", "namespace", "runtime", "entrypoint"],
+      "properties": {
+        "apiVersion": { "type": "integer", "enum": [1] },
+        "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$" },
+        "namespace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,38}$" },
+        "runtime": { "type": "string" },
+        "entrypoint": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source": { "$ref": "#/definitions/source" },
+    "published": {
+      "type": "string",
+      "description": "RFC 3339 publish timestamp (informational)."
+    },
+    "yanked": { "type": "boolean" },
+    "yank_reason": { "type": "string" }
+  },
+  "definitions": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where the bytes live. The git form is the v1 source-of-record; the binary form records per-platform artifacts. At least one must be usable.",
+      "properties": {
+        "git": { "type": "string", "minLength": 1 },
+        "rev": {
+          "type": "string",
+          "description": "A full, immutable git object id (SHA-1 = 40 hex, SHA-256 = 64 hex). A branch/tag name would make the pin mutable.",
+          "pattern": "^[0-9a-f]{40}([0-9a-f]{24})?$"
+        },
+        "subdir": {
+          "type": "string",
+          "description": "Where in the repository the node lives (monorepo support). Forward slashes, relative, no `..`.",
+          "pattern": "^(?!.*\\.\\.)(?!/)[^\\\\]+$"
+        },
+        "binary": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/binaryArtifact" }
+        },
+        "fallback-git": { "$ref": "#/definitions/source" }
+      },
+      "anyOf": [
+        { "required": ["git", "rev"] },
+        { "required": ["binary"] }
+      ]
+    },
+    "binaryArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "url", "sha256"],
+      "properties": {
+        "platform": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    }
+  }
+}

--- a/schemas/node-index-entry.schema.json
+++ b/schemas/node-index-entry.schema.json
@@ -46,6 +46,7 @@
         },
         "binary": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/binaryArtifact" }
         },
         "fallback-git": { "$ref": "#/definitions/source" }

--- a/schemas/node-index-package.schema.json
+++ b/schemas/node-index-package.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/dora-rs/dora-hub/schemas/node-index-package.schema.json",
+  "title": "Dora Hub node-index package metadata",
+  "description": "Namespace/package-level metadata (`package.yml`): description, repo, and the OWNERS list that index CI checks publishes against. Mirrors the CLI's `PackageMeta`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["owners"],
+  "properties": {
+    "description": { "type": "string" },
+    "repo": { "type": "string" },
+    "owners": {
+      "type": "array",
+      "description": "GitHub accounts (or orgs) allowed to publish into this package. Enforced by index CI (§7.5).",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$" }
+    }
+  }
+}

--- a/scripts/index-ci/check_append_only.py
+++ b/scripts/index-ci/check_append_only.py
@@ -71,6 +71,13 @@ def show(ref_path: str) -> dict:
 def allowed_version_edit(old: dict, new: dict) -> str | None:
     """None if the edit is an allowed yank/binary-add; else a reason string."""
 
+    # a yank must carry a non-empty reason (§7.5); otherwise the yank/yank_reason
+    # pair is stripped below and any yank state would pass unchecked
+    if new.get("yanked") is True:
+        reason = new.get("yank_reason")
+        if not (isinstance(reason, str) and reason.strip()):
+            return "`yanked: true` requires a non-empty `yank_reason`"
+
     def strip_mutable(entry: dict) -> dict:
         e = copy.deepcopy(entry)
         e.pop("yanked", None)

--- a/scripts/index-ci/check_append_only.py
+++ b/scripts/index-ci/check_append_only.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Enforce the append-only rule on `node-index/` (Hub P2.3, spec §7.5).
+
+A published version file is immutable. Across a PR, index CI permits:
+  - ADDING new files (new versions, packages, namespaces);
+  - on an existing `<version>.yml`, ONLY flipping `yanked` (+ `yank_reason`)
+    and/or ADDING late `source.binary` platform entries.
+
+Everything else — deleting/renaming a version file, or any other edit to its
+content — fails and needs an index admin. `package.yml` edits (owners/metadata)
+are allowed here but flagged for human review (the bot, not this script, gates
+auto-merge on them, spec §7.5).
+
+Usage: check_append_only.py [--base <ref>]
+  base defaults to origin/$GITHUB_BASE_REF, else origin/main.
+Compares `<merge-base(base, HEAD)>..HEAD`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import subprocess
+import sys
+
+import yaml
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def changed_index_files(base: str) -> list[tuple[str, str, str | None]]:
+    """Return (status, path, old_path) for changed files under node-index/."""
+    merge_base = git("merge-base", base, "HEAD").strip()
+    out = git("diff", "--name-status", "-M", f"{merge_base}", "HEAD")
+    changes: list[tuple[str, str, str | None]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        cols = line.split("\t")
+        status = cols[0]
+        if status.startswith("R"):  # rename: R<score>\told\tnew
+            old, new = cols[1], cols[2]
+            if _under_index(old) or _under_index(new):
+                changes.append(("R", new, old))
+        else:
+            path = cols[1]
+            if _under_index(path):
+                changes.append((status[0], path, None))
+    return changes
+
+
+def _under_index(path: str) -> bool:
+    return path.startswith("node-index/") and path.endswith(".yml")
+
+
+def _is_version_entry(path: str) -> bool:
+    return path.endswith(".yml") and not path.endswith("/package.yml")
+
+
+def show(ref_path: str) -> dict:
+    text = git("show", ref_path)
+    doc = yaml.safe_load(text)
+    return doc if isinstance(doc, dict) else {}
+
+
+def allowed_version_edit(old: dict, new: dict) -> str | None:
+    """None if the edit is an allowed yank/binary-add; else a reason string."""
+
+    def strip_mutable(entry: dict) -> dict:
+        e = copy.deepcopy(entry)
+        e.pop("yanked", None)
+        e.pop("yank_reason", None)
+        return e
+
+    o, n = strip_mutable(old), strip_mutable(new)
+
+    o_src = o.pop("source", {}) or {}
+    n_src = n.pop("source", {}) or {}
+    o_bins = o_src.pop("binary", []) or []
+    n_bins = n_src.pop("binary", []) or []
+
+    # existing binary artifacts must survive unchanged; new ones may be appended
+    for b in o_bins:
+        if b not in n_bins:
+            return "an existing `source.binary` artifact was changed or removed"
+
+    if o_src != n_src:
+        return "`source` changed beyond appending binary artifacts"
+    if o != n:
+        return "the entry changed beyond `yanked`/`yank_reason` or binary additions"
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    default_base = (
+        f"origin/{os.environ['GITHUB_BASE_REF']}"
+        if os.environ.get("GITHUB_BASE_REF")
+        else "origin/main"
+    )
+    ap.add_argument("--base", default=default_base)
+    args = ap.parse_args()
+
+    in_actions = os.environ.get("GITHUB_ACTIONS") == "true"
+
+    def emit(level: str, msg: str) -> None:
+        print(f"::{level}::{msg}" if in_actions else f"{level}: {msg}")
+
+    try:
+        changes = changed_index_files(args.base)
+    except subprocess.CalledProcessError as e:
+        emit("error", f"git diff against `{args.base}` failed: {e.stderr.strip()}")
+        return 1
+
+    errors = 0
+    for status, path, old_path in changes:
+        if status == "A":
+            continue  # adding a new file is always allowed
+        if status == "D":
+            emit("error", f"{path}: a published index file must not be deleted (append-only)")
+            errors += 1
+            continue
+        if status == "R":
+            emit(
+                "error",
+                f"{old_path} -> {path}: a published index file must not be renamed/moved",
+            )
+            errors += 1
+            continue
+        if status == "M":
+            if not _is_version_entry(path):
+                emit("warning", f"{path}: package metadata changed — needs human review")
+                continue
+            merge_base = git("merge-base", args.base, "HEAD").strip()
+            old = show(f"{merge_base}:{path}")
+            new = show(f"HEAD:{path}")
+            reason = allowed_version_edit(old, new)
+            if reason:
+                emit("error", f"{path}: {reason} — published versions are immutable (§7.5)")
+                errors += 1
+            continue
+        emit("error", f"{path}: unexpected change status `{status}`")
+        errors += 1
+
+    if errors:
+        print(f"\ncheck_append_only: {errors} violation(s)")
+        return 1
+    print(f"check_append_only: OK ({len(changes)} index change(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/index-ci/check_append_only.py
+++ b/scripts/index-ci/check_append_only.py
@@ -89,6 +89,14 @@ def allowed_version_edit(old: dict, new: dict) -> str | None:
         if b not in n_bins:
             return "an existing `source.binary` artifact was changed or removed"
 
+    # an appended artifact may only cover a platform not already pinned —
+    # re-adding an existing platform with a different url/sha shadows the
+    # original (consumers that take the last match would resolve the new one)
+    o_platforms = {b.get("platform") for b in o_bins}
+    for b in n_bins:
+        if b not in o_bins and b.get("platform") in o_platforms:
+            return "a `source.binary` platform already pinned was re-added (shadowing)"
+
     if o_src != n_src:
         return "`source` changed beyond appending binary artifacts"
     if o != n:

--- a/scripts/index-ci/reserved_namespaces.txt
+++ b/scripts/index-ci/reserved_namespaces.txt
@@ -1,0 +1,13 @@
+# Namespaces reserved for the project / type system. A new claim (a fresh
+# `node-index/<ns>/` package.yml) for one of these requires an index admin —
+# index CI flags it for human review instead of auto-merging (spec §7.4).
+# One namespace per line; blank lines and `#` comments ignored.
+dora
+dora-rs
+dora-hub
+std
+official
+hub
+index
+node
+nodes

--- a/scripts/index-ci/tests/fixtures/badrev/example-node/0.1.0.yml
+++ b/scripts/index-ci/tests/fixtures/badrev/example-node/0.1.0.yml
@@ -1,0 +1,10 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: badrev
+  runtime: python
+  entrypoint: x
+source:
+  git: https://example.com/repo
+  rev: deadbeef
+  subdir: node-hub/example-node

--- a/scripts/index-ci/tests/fixtures/dora-rs/example-node/0.1.0.yml
+++ b/scripts/index-ci/tests/fixtures/dora-rs/example-node/0.1.0.yml
@@ -1,0 +1,13 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: dora-rs
+  runtime: python
+  entrypoint: example_node.main:main
+  description: An example node used by index-CI fixtures.
+source:
+  git: https://github.com/dora-rs/dora-hub
+  rev: 0123456789abcdef0123456789abcdef01234567
+  subdir: node-hub/example-node
+published: "2026-07-01T12:00:00Z"
+yanked: false

--- a/scripts/index-ci/tests/fixtures/dora-rs/example-node/latest.yml
+++ b/scripts/index-ci/tests/fixtures/dora-rs/example-node/latest.yml
@@ -1,0 +1,9 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: dora-rs
+  runtime: python
+  entrypoint: x
+source:
+  git: https://example.com/repo
+  rev: 0123456789abcdef0123456789abcdef01234567

--- a/scripts/index-ci/tests/fixtures/dora-rs/example-node/package.yml
+++ b/scripts/index-ci/tests/fixtures/dora-rs/example-node/package.yml
@@ -1,0 +1,4 @@
+description: An example node.
+repo: https://github.com/dora-rs/dora-hub
+owners:
+  - dora-rs

--- a/scripts/index-ci/tests/fixtures/dupplat/example-node/0.1.0.yml
+++ b/scripts/index-ci/tests/fixtures/dupplat/example-node/0.1.0.yml
@@ -1,0 +1,17 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: dupplat
+  runtime: python
+  entrypoint: example_node.main:main
+  description: Two artifacts claim the same platform.
+source:
+  binary:
+    - platform: x86_64-unknown-linux-gnu
+      url: https://example.com/a.tar.gz
+      sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - platform: x86_64-unknown-linux-gnu
+      url: https://example.com/b.tar.gz
+      sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+published: "2026-07-01T12:00:00Z"
+yanked: false

--- a/scripts/index-ci/tests/fixtures/dupplat/example-node/package.yml
+++ b/scripts/index-ci/tests/fixtures/dupplat/example-node/package.yml
@@ -1,0 +1,4 @@
+description: An example node with a duplicate-platform binary source.
+repo: https://github.com/dora-rs/dora-hub
+owners:
+  - dora-rs

--- a/scripts/index-ci/tests/fixtures/mismatch/example-node/0.1.0.yml
+++ b/scripts/index-ci/tests/fixtures/mismatch/example-node/0.1.0.yml
@@ -1,0 +1,9 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: dora-rs
+  runtime: python
+  entrypoint: x
+source:
+  git: https://example.com/repo
+  rev: 0123456789abcdef0123456789abcdef01234567

--- a/scripts/index-ci/tests/fixtures/noowners/example-node/package.yml
+++ b/scripts/index-ci/tests/fixtures/noowners/example-node/package.yml
@@ -1,0 +1,1 @@
+description: missing owners

--- a/scripts/index-ci/tests/fixtures/nopkg/example-node/0.1.0.yml
+++ b/scripts/index-ci/tests/fixtures/nopkg/example-node/0.1.0.yml
@@ -1,0 +1,13 @@
+manifest:
+  apiVersion: 1
+  name: example-node
+  namespace: nopkg
+  runtime: python
+  entrypoint: example_node.main:main
+  description: A version entry with no sibling package.yml.
+source:
+  git: https://github.com/dora-rs/dora-hub
+  rev: 0123456789abcdef0123456789abcdef01234567
+  subdir: node-hub/example-node
+published: "2026-07-01T12:00:00Z"
+yanked: false

--- a/scripts/index-ci/tests/fixtures/std/example-node/package.yml
+++ b/scripts/index-ci/tests/fixtures/std/example-node/package.yml
@@ -1,0 +1,3 @@
+description: reserved-namespace claim
+owners:
+  - somebody

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -69,6 +69,9 @@ def test_validate() -> None:
     rc, out = run_validate("nopkg/example-node/0.1.0.yml")
     check("version without sibling package.yml rejected", rc == 1 and "package.yml" in out, out)
 
+    rc, out = run_validate("dupplat/example-node/0.1.0.yml")
+    check("duplicate binary platform rejected", rc == 1 and "duplicate" in out and "platform" in out, out)
+
 
 def test_empty_binary_rejected() -> None:
     print("node-index-entry.schema empty-binary guard:")
@@ -88,17 +91,29 @@ def test_symlink_rejected() -> None:
         outside.write_text("manifest: {}\n")
         entry = tdp / "index" / "ns" / "pkg"
         entry.mkdir(parents=True)
+        # an escaping symlink and a dangling one (missing target) — both must be
+        # rejected, not silently skipped by the containment / exists() guards
         link = entry / "1.0.0.yml"
         link.symlink_to(outside)
+        dangling = entry / "2.0.0.yml"
+        dangling.symlink_to(tdp / "does-not-exist.yml")
         saved = ve.INDEX_ROOT
         ve.INDEX_ROOT = tdp / "index"
         try:
+            # explicit-arg path
+            for label, target in (("escaping", link), ("dangling", dangling)):
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    rc = ve.main([str(target)])
+                check(f"{label} symlink rejected (explicit)", rc == 1 and "symlink" in buf.getvalue(), buf.getvalue())
+            # whole-tree scan must surface both, not skip them
             buf = io.StringIO()
             with contextlib.redirect_stdout(buf):
-                rc = ve.main([str(link)])
+                rc = ve.main([])
+            out = buf.getvalue()
+            check("dangling symlink caught by tree scan", rc == 1 and out.count("symlink") >= 2, out)
         finally:
             ve.INDEX_ROOT = saved
-        check("symlinked catalog entry rejected", rc == 1 and "symlink" in buf.getvalue(), buf.getvalue())
 
 
 def test_append_only() -> None:
@@ -112,6 +127,12 @@ def test_append_only() -> None:
 
     yanked = {**base, "yanked": True, "yank_reason": "broken"}
     check("yank flip allowed", cao.allowed_version_edit(base, yanked) is None)
+
+    yanked_no_reason = {**base, "yanked": True}
+    check("yank without reason rejected", cao.allowed_version_edit(base, yanked_no_reason) is not None)
+
+    yanked_blank_reason = {**base, "yanked": True, "yank_reason": "   "}
+    check("yank with blank reason rejected", cao.allowed_version_edit(base, yanked_blank_reason) is not None)
 
     unyank = {**base, "yanked": False}
     check("no-op allowed", cao.allowed_version_edit(base, unyank) is None)

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -66,6 +66,40 @@ def test_validate() -> None:
     rc, out = run_validate("std/example-node/package.yml")
     check("reserved namespace warns but passes", rc == 0 and "reserved" in out, out)
 
+    rc, out = run_validate("nopkg/example-node/0.1.0.yml")
+    check("version without sibling package.yml rejected", rc == 1 and "package.yml" in out, out)
+
+
+def test_empty_binary_rejected() -> None:
+    print("node-index-entry.schema empty-binary guard:")
+    check("git+rev source accepted", _source_ok({"git": "g", "rev": "f" * 40}))
+    check("non-empty binary source accepted", _source_ok({"binary": [{"platform": "x", "url": "u", "sha256": "a" * 64}]}))
+    # an empty binary list is not a usable source — must not satisfy the anyOf
+    check("empty binary list rejected", not _source_ok({"binary": []}))
+
+
+def test_symlink_rejected() -> None:
+    import tempfile
+
+    print("validate_entries symlink guard:")
+    with tempfile.TemporaryDirectory() as td:
+        tdp = pathlib.Path(td)
+        outside = tdp / "secret.yml"
+        outside.write_text("manifest: {}\n")
+        entry = tdp / "index" / "ns" / "pkg"
+        entry.mkdir(parents=True)
+        link = entry / "1.0.0.yml"
+        link.symlink_to(outside)
+        saved = ve.INDEX_ROOT
+        ve.INDEX_ROOT = tdp / "index"
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = ve.main([str(link)])
+        finally:
+            ve.INDEX_ROOT = saved
+        check("symlinked catalog entry rejected", rc == 1 and "symlink" in buf.getvalue(), buf.getvalue())
+
 
 def test_append_only() -> None:
     print("check_append_only.allowed_version_edit:")
@@ -107,15 +141,29 @@ def test_append_only() -> None:
     check("changing the manifest rejected", cao.allowed_version_edit(base, changed_manifest) is not None)
 
 
-def test_subdir_no_traversal() -> None:
-    print("node-index-entry.schema subdir traversal guard:")
+def _source_ok(source: dict) -> bool:
+    """Validate a `source` stanza against the real entry schema (refs resolved)."""
     import jsonschema
 
-    schema = ve.load_schema("node-index-entry.schema.json")["definitions"]["source"]
+    schema = ve.load_schema("node-index-entry.schema.json")
+    doc = {
+        "manifest": {
+            "apiVersion": 1,
+            "name": "n",
+            "namespace": "ns",
+            "runtime": "python",
+            "entrypoint": "x:main",
+        },
+        "source": source,
+    }
+    return not list(jsonschema.Draft7Validator(schema).iter_errors(doc))
+
+
+def test_subdir_no_traversal() -> None:
+    print("node-index-entry.schema subdir traversal guard:")
 
     def subdir_ok(value: str) -> bool:
-        doc = {"git": "g", "rev": "f" * 40, "subdir": value}
-        return not list(jsonschema.Draft7Validator(schema).iter_errors(doc))
+        return _source_ok({"git": "g", "rev": "f" * 40, "subdir": value})
 
     check("plain subdir accepted", subdir_ok("node-hub/dora-yolo"))
     check("leading-slash subdir rejected", not subdir_ok("/etc"))
@@ -128,4 +176,6 @@ if __name__ == "__main__":
     test_validate()
     test_append_only()
     test_subdir_no_traversal()
+    test_empty_binary_rejected()
+    test_symlink_rejected()
     print(f"\nall index-ci tests passed ({PASSED} checks)")

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -97,11 +97,35 @@ def test_append_only() -> None:
     }
     check("mutating an existing binary rejected", cao.allowed_version_edit(base, changed_bin) is not None)
 
+    shadow_bin = {
+        **base,
+        "source": {**base["source"], "binary": base["source"]["binary"] + [{"platform": "x", "url": "EVIL", "sha256": "s2"}]},
+    }
+    check("re-adding a pinned platform (shadowing) rejected", cao.allowed_version_edit(base, shadow_bin) is not None)
+
     changed_manifest = {**base, "manifest": {"name": "n", "namespace": "OTHER"}}
     check("changing the manifest rejected", cao.allowed_version_edit(base, changed_manifest) is not None)
+
+
+def test_subdir_no_traversal() -> None:
+    print("node-index-entry.schema subdir traversal guard:")
+    import jsonschema
+
+    schema = ve.load_schema("node-index-entry.schema.json")["definitions"]["source"]
+
+    def subdir_ok(value: str) -> bool:
+        doc = {"git": "g", "rev": "f" * 40, "subdir": value}
+        return not list(jsonschema.Draft7Validator(schema).iter_errors(doc))
+
+    check("plain subdir accepted", subdir_ok("node-hub/dora-yolo"))
+    check("leading-slash subdir rejected", not subdir_ok("/etc"))
+    check("dotdot subdir rejected", not subdir_ok("../etc"))
+    # the `..` guard must not be defeated by smuggling it onto a second line
+    check("newline-smuggled dotdot rejected", not subdir_ok("ok\n../../etc"))
 
 
 if __name__ == "__main__":
     test_validate()
     test_append_only()
+    test_subdir_no_traversal()
     print(f"\nall index-ci tests passed ({PASSED} checks)")

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Self-contained tests for the index-CI scripts (no pytest needed).
+
+Run: `python3 scripts/index-ci/tests/test_index_ci.py`
+Exits non-zero on the first failure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+FIXTURES = HERE / "fixtures"
+SCRIPTS = HERE.parent
+sys.path.insert(0, str(SCRIPTS))
+
+# point the validator at the fixture tree before importing it
+os.environ["DORA_INDEX_ROOT"] = str(FIXTURES)
+
+import check_append_only as cao  # noqa: E402
+import validate_entries as ve  # noqa: E402
+
+PASSED = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED
+    if cond:
+        PASSED += 1
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        raise SystemExit(1)
+
+
+def run_validate(*relpaths: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = ve.main([str(FIXTURES / p) for p in relpaths])
+    return rc, buf.getvalue()
+
+
+def test_validate() -> None:
+    print("validate_entries:")
+    rc, _ = run_validate(
+        "dora-rs/example-node/0.1.0.yml", "dora-rs/example-node/package.yml"
+    )
+    check("good entry + package pass", rc == 0)
+
+    rc, out = run_validate("badrev/example-node/0.1.0.yml")
+    check("short rev rejected", rc == 1 and "rev" in out, out)
+
+    rc, out = run_validate("mismatch/example-node/0.1.0.yml")
+    check("namespace/path mismatch rejected", rc == 1 and "directory" in out, out)
+
+    rc, out = run_validate("dora-rs/example-node/latest.yml")
+    check("non-semver filename rejected", rc == 1 and "semver" in out, out)
+
+    rc, out = run_validate("noowners/example-node/package.yml")
+    check("package without owners rejected", rc == 1 and "owners" in out, out)
+
+    rc, out = run_validate("std/example-node/package.yml")
+    check("reserved namespace warns but passes", rc == 0 and "reserved" in out, out)
+
+
+def test_append_only() -> None:
+    print("check_append_only.allowed_version_edit:")
+    base = {
+        "manifest": {"name": "n", "namespace": "ns"},
+        "source": {"git": "g", "rev": "r", "binary": [{"platform": "x", "url": "u", "sha256": "s"}]},
+        "published": "t",
+        "yanked": False,
+    }
+
+    yanked = {**base, "yanked": True, "yank_reason": "broken"}
+    check("yank flip allowed", cao.allowed_version_edit(base, yanked) is None)
+
+    unyank = {**base, "yanked": False}
+    check("no-op allowed", cao.allowed_version_edit(base, unyank) is None)
+
+    added_bin = {
+        **base,
+        "source": {**base["source"], "binary": base["source"]["binary"] + [{"platform": "y", "url": "u2", "sha256": "s2"}]},
+    }
+    check("appending a binary allowed", cao.allowed_version_edit(base, added_bin) is None)
+
+    changed_rev = {**base, "source": {**base["source"], "rev": "OTHER"}}
+    check("changing rev rejected", cao.allowed_version_edit(base, changed_rev) is not None)
+
+    changed_bin = {
+        **base,
+        "source": {**base["source"], "binary": [{"platform": "x", "url": "EVIL", "sha256": "s"}]},
+    }
+    check("mutating an existing binary rejected", cao.allowed_version_edit(base, changed_bin) is not None)
+
+    changed_manifest = {**base, "manifest": {"name": "n", "namespace": "OTHER"}}
+    check("changing the manifest rejected", cao.allowed_version_edit(base, changed_manifest) is not None)
+
+
+if __name__ == "__main__":
+    test_validate()
+    test_append_only()
+    print(f"\nall index-ci tests passed ({PASSED} checks)")

--- a/scripts/index-ci/validate_entries.py
+++ b/scripts/index-ci/validate_entries.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate dora-hub `node-index/` catalog entries (Hub P2.3, spec §7).
+
+For each catalog file:
+  - `<ns>/<name>/<version>.yml`  -> a version entry (manifest + source pointer)
+  - `<ns>/<name>/package.yml`     -> package metadata (description, repo, owners)
+
+it checks the JSON schema, the path<->content consistency (namespace/name match
+the directory, filename is valid semver), and the key-part charset. Reserved
+namespaces are reported (they need an admin, spec §7.4) but not hard-failed here
+— that gating is the bot's job (PR 3).
+
+Usage:
+  validate_entries.py [FILE ...]      # validate the given files
+  validate_entries.py                 # scan the whole node-index/ tree
+
+Exits non-zero if any file fails. Designed to run in CI over the PR's changed
+files, and locally over fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+import jsonschema
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCHEMA_DIR = REPO_ROOT / "schemas"
+# Overridable for tests (point at a fixture tree); defaults to the real catalog.
+INDEX_ROOT = pathlib.Path(os.environ.get("DORA_INDEX_ROOT", REPO_ROOT / "node-index"))
+RESERVED_FILE = pathlib.Path(__file__).resolve().parent / "reserved_namespaces.txt"
+
+# X.Y.Z with optional -prerelease and +build (a pragmatic semver 2.0 subset;
+# the CLI's `semver` crate is the authority, this is the CI gate).
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+NAMESPACE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,38}$")
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+def load_reserved() -> set[str]:
+    out = set()
+    for line in RESERVED_FILE.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return out
+
+
+def load_schema(name: str) -> dict:
+    return json.loads((SCHEMA_DIR / name).read_text())
+
+
+def rel(path: pathlib.Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def index_files() -> list[pathlib.Path]:
+    return sorted(p for p in INDEX_ROOT.rglob("*.yml") if p.is_file())
+
+
+def validate_file(
+    path: pathlib.Path,
+    entry_schema: dict,
+    package_schema: dict,
+    reserved: set[str],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    rp = rel(path)
+    try:
+        parts = path.resolve().relative_to(INDEX_ROOT).parts
+    except ValueError:
+        # not under node-index/ — nothing to validate
+        return
+    if len(parts) != 3:
+        errors.append(
+            f"{rp}: catalog files must live at node-index/<ns>/<name>/<file>.yml"
+        )
+        return
+    namespace, name, filename = parts
+
+    if not NAMESPACE_RE.match(namespace):
+        errors.append(f"{rp}: invalid namespace `{namespace}` (want [a-z0-9-], <=39)")
+    if not NAME_RE.match(name):
+        errors.append(f"{rp}: invalid package name `{name}` (want [a-z0-9._-], <=64)")
+
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as e:
+        errors.append(f"{rp}: not valid YAML: {e}")
+        return
+    if not isinstance(doc, dict):
+        errors.append(f"{rp}: expected a YAML mapping")
+        return
+
+    if filename == "package.yml":
+        _schema_check(package_schema, doc, rp, errors)
+        if namespace in reserved:
+            warnings.append(
+                f"{rp}: namespace `{namespace}` is reserved — needs an index admin "
+                f"(spec §7.4), not auto-merge"
+            )
+        return
+
+    # version entry: filename stem must be semver
+    stem = filename[:-4] if filename.endswith(".yml") else filename
+    if not SEMVER_RE.match(stem):
+        errors.append(f"{rp}: filename `{filename}` is not a `<semver>.yml`")
+    _schema_check(entry_schema, doc, rp, errors)
+
+    manifest = doc.get("manifest", {})
+    if isinstance(manifest, dict):
+        if manifest.get("namespace") != namespace:
+            errors.append(
+                f"{rp}: manifest.namespace `{manifest.get('namespace')}` "
+                f"!= directory `{namespace}`"
+            )
+        if manifest.get("name") != name:
+            errors.append(
+                f"{rp}: manifest.name `{manifest.get('name')}` != directory `{name}`"
+            )
+
+
+def _schema_check(schema: dict, doc: dict, rp: str, errors: list[str]) -> None:
+    validator = jsonschema.Draft7Validator(schema)
+    for err in sorted(validator.iter_errors(doc), key=lambda e: e.path):
+        loc = "/".join(str(p) for p in err.path) or "(root)"
+        errors.append(f"{rp}: schema: {loc}: {err.message}")
+
+
+def main(argv: list[str]) -> int:
+    entry_schema = load_schema("node-index-entry.schema.json")
+    package_schema = load_schema("node-index-package.schema.json")
+    reserved = load_reserved()
+
+    if argv:
+        targets = [pathlib.Path(a) for a in argv]
+    else:
+        targets = index_files()
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+    for path in targets:
+        if not path.exists():
+            # a deleted file shows up in a changed-files list — append-only CI
+            # handles deletions; nothing to validate here
+            continue
+        if path.suffix != ".yml":
+            continue
+        try:
+            path.resolve().relative_to(INDEX_ROOT)
+        except ValueError:
+            continue
+        checked += 1
+        validate_file(path, entry_schema, package_schema, reserved, errors, warnings)
+
+    for w in warnings:
+        print(f"::warning::{w}" if _in_actions() else f"warning: {w}")
+    for e in errors:
+        print(f"::error::{e}" if _in_actions() else f"error: {e}")
+
+    if errors:
+        print(f"\nvalidate_entries: {len(errors)} error(s) in {checked} file(s)")
+        return 1
+    print(f"validate_entries: OK ({checked} file(s) checked)")
+    return 0
+
+
+def _in_actions() -> bool:
+    import os
+
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/index-ci/validate_entries.py
+++ b/scripts/index-ci/validate_entries.py
@@ -67,7 +67,10 @@ def rel(path: pathlib.Path) -> str:
 
 
 def index_files() -> list[pathlib.Path]:
-    return sorted(p for p in INDEX_ROOT.rglob("*.yml") if p.is_file())
+    # include symlinks (even dangling ones) so they get rejected, not skipped
+    return sorted(
+        p for p in INDEX_ROOT.rglob("*.yml") if p.is_file() or p.is_symlink()
+    )
 
 
 def validate_file(
@@ -126,6 +129,7 @@ def validate_file(
             f"(description, repo, owners) alongside its versions"
         )
     _schema_check(entry_schema, doc, rp, errors)
+    _check_binary_platforms(doc.get("source"), rp, errors)
 
     manifest = doc.get("manifest", {})
     if isinstance(manifest, dict):
@@ -138,6 +142,25 @@ def validate_file(
             errors.append(
                 f"{rp}: manifest.name `{manifest.get('name')}` != directory `{name}`"
             )
+
+
+def _check_binary_platforms(source, rp: str, errors: list[str]) -> None:
+    """Each `platform` in a `source.binary` list must be unique — a duplicate
+    lets first/last-match consumers resolve different artifacts for one platform
+    (the same ambiguity the append-only shadow check guards against). Recurses
+    into `fallback-git`."""
+    if not isinstance(source, dict):
+        return
+    seen: set[str] = set()
+    for art in source.get("binary") or []:
+        if not isinstance(art, dict):
+            continue
+        plat = art.get("platform")
+        if plat in seen:
+            errors.append(f"{rp}: duplicate `source.binary` platform `{plat}`")
+        elif plat is not None:
+            seen.add(plat)
+    _check_binary_platforms(source.get("fallback-git"), rp, errors)
 
 
 def _schema_check(schema: dict, doc: dict, rp: str, errors: list[str]) -> None:
@@ -161,19 +184,21 @@ def main(argv: list[str]) -> int:
     warnings: list[str] = []
     checked = 0
     for path in targets:
-        if not path.exists():
-            # a deleted file shows up in a changed-files list — append-only CI
-            # handles deletions; nothing to validate here
-            continue
         if path.suffix != ".yml":
             continue
         # A catalog entry must be a real file inside the index. A symlink can
-        # resolve outside INDEX_ROOT and would otherwise be silently skipped by
-        # the containment check below, smuggling unvalidated content into the
-        # catalog (check_append_only treats added files as allowed).
+        # resolve outside INDEX_ROOT (or dangle) and would otherwise be silently
+        # skipped — by the exists() guard below if dangling, or the containment
+        # check if it escapes — smuggling unvalidated content into the catalog
+        # (check_append_only treats added files as allowed). Check before
+        # exists() so a dangling symlink is rejected, not skipped.
         if path.is_symlink():
             checked += 1
             errors.append(f"{rel(path)}: catalog entries must be regular files, not symlinks")
+            continue
+        if not path.exists():
+            # a deleted file shows up in a changed-files list — append-only CI
+            # handles deletions; nothing to validate here
             continue
         try:
             path.resolve().relative_to(INDEX_ROOT)

--- a/scripts/index-ci/validate_entries.py
+++ b/scripts/index-ci/validate_entries.py
@@ -118,6 +118,13 @@ def validate_file(
     stem = filename[:-4] if filename.endswith(".yml") else filename
     if not SEMVER_RE.match(stem):
         errors.append(f"{rp}: filename `{filename}` is not a `<semver>.yml`")
+    # every published version needs package metadata (owners) to anchor the
+    # later owner/bot checks; a version with no sibling package.yml is orphaned
+    if not (path.parent / "package.yml").is_file():
+        errors.append(
+            f"{rp}: no sibling `package.yml` — every node needs package metadata "
+            f"(description, repo, owners) alongside its versions"
+        )
     _schema_check(entry_schema, doc, rp, errors)
 
     manifest = doc.get("manifest", {})
@@ -159,6 +166,14 @@ def main(argv: list[str]) -> int:
             # handles deletions; nothing to validate here
             continue
         if path.suffix != ".yml":
+            continue
+        # A catalog entry must be a real file inside the index. A symlink can
+        # resolve outside INDEX_ROOT and would otherwise be silently skipped by
+        # the containment check below, smuggling unvalidated content into the
+        # catalog (check_append_only treats added files as allowed).
+        if path.is_symlink():
+            checked += 1
+            errors.append(f"{rel(path)}: catalog entries must be regular files, not symlinks")
             continue
         try:
             path.resolve().relative_to(INDEX_ROOT)


### PR DESCRIPTION
## What

PR 1 of 3 for **Hub P2.3** (#65): bootstrap the `node-index/` catalog and its CI **in this repo**. This is the keystone the rest of Phase 3 waits on — the migration (#63) and CI hardening (#64) both need the catalog + base index CI to exist.

The `dora hub` CLI that produces and consumes these entries is already merged in `dora-rs/dora` (publish/yank/outdated/update). Spec: [`docs/plan-node-hub.md` §7](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md).

## Contents

- **`node-index/`** + README documenting the catalog format (`<ns>/<name>/<version>.yml` = manifest + source pointer) and the publish flow (`dora hub publish` → PR).
- **`schemas/`** — JSON Schema for a version entry (manifest + `source{git,rev,subdir|binary,fallback-git}` + `published`/`yanked`/`yank_reason`) and for `package.yml` (owners), mirroring the CLI's `IndexEntry` / `PackageMeta`.
- **`scripts/index-ci/`**:
  - `validate_entries.py` — schema + path↔content consistency (namespace/name match the dir, filename is semver) + full 40/64-hex pin + charset; reserved namespaces flagged for review.
  - `check_append_only.py` — the §7.5 rule: published version files are immutable; only `yanked`(+reason) flips and *additive* `source.binary` entries are allowed; deletions/renames/other edits fail.
  - Self-contained unit tests + fixtures (12 checks, no pytest needed).
- **`.github/workflows/node-index-ci.yml`** — runs all of the above, **path-scoped to `node-index/**`** (+ schemas/scripts) so it never runs on, or gates, the human-reviewed `node-hub/` source path.
- **`publish-node` PR template.**

## Deliberately deferred (per the issue split)
- **PR 2** — namespace-identity governance: claimant == GitHub login/org (API), OWNERS enforcement, confusable/edit-distance screening, dispute policy doc.
- **PR 3** — the auto-merge bot (auto-merge passing `node-index/**` PRs; human-review carve-outs for new namespaces / OWNERS / yank-by-non-owner / CI changes).

## Test plan
- [x] `python3 scripts/index-ci/tests/test_index_ci.py` — 12 checks (good entry/package pass; short rev, ns/path mismatch, non-semver filename, missing owners rejected; reserved ns warns; yank-flip & binary-append allowed; rev/binary/manifest mutation rejected).
- [x] `validate_entries.py` and `check_append_only.py` run clean against the branch; verified end-to-end that mutating a pinned `rev` on an existing entry fails the append-only check.

Note for a maintainer: once merged, `node-index CI` should be added to the branch-protection required checks **for PRs that touch `node-index/**`** (it's path-scoped, so it won't block unrelated `node-hub/` PRs).
