### PR TITLE
chore(dev): CLAUDE.md + local QA helper, shared ruff baseline, contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+This file provides guidance to Codex and other agentic coding tools working in
+this repository. It complements, but does not replace, [`CLAUDE.md`](CLAUDE.md).
+If the two documents overlap, follow the stricter rule.
+
+> Reconstructed after the original was accidentally deleted — please replace or
+> edit to match your intent.
+
+## Start here
+
+`dora-hub` is the collection of reusable [dora](https://github.com/dora-rs/dora)
+nodes (~60), and it also hosts the Dora Hub catalog (`node-index/`). Most nodes
+are Python (built/tested with **uv**, linted with **ruff**, tested with
+**pytest**); some are Rust members of the root Cargo workspace, and a few are
+Rust+Python (maturin) hybrids.
+
+**Read [`CLAUDE.md`](CLAUDE.md) first** — it is the canonical reference for the
+repo map, build/test commands, the CI structure, and the pre-commit gates.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) covers how to add a node.
+
+## Working rules
+
+- **Surgical changes.** Touch only what the task needs and match the surrounding
+  style. Don't fix unrelated warnings or reformat code you aren't changing.
+- **One node at a time.** A node lives in `node-hub/<name>/`. Preserve the 1:1:1
+  packaging convention: the PyPI dist name, the `[project.scripts]`
+  console-script, and the `path:` a dataflow uses are all the same string.
+- **Verify what you change.** `make test-node NODE=<name>` runs exactly what CI
+  runs for one node (uv + ruff + pytest, or cargo). For Rust workspace changes,
+  `make test-rust` and `make lint`. For `node-index/` changes, `make index-ci`.
+- **Don't hand-edit the catalog.** `node-index/` entries come from
+  `dora hub publish`; published version files are immutable (append-only).
+
+## Before you finish
+
+Run the pre-commit gates for what you touched (see CLAUDE.md → "Pre-commit
+Quality Gates"): the changed node's `make test-node`, plus `cargo
+fmt`/`clippy`/`test` for Rust, `make index-ci` for the catalog, and `typos`.
+Don't push red.
+
+## Don'ts
+
+- Don't commit secrets, a node's `.venv/`, or build artifacts.
+- Don't switch git branches or run destructive git commands in a shared working
+  tree without saying so first.
+- Don't add a `.ci-skip` / `.skip-test` marker to paper over a real failure —
+  fix the node, or flag the breakage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,6 @@ This file provides guidance to Codex and other agentic coding tools working in
 this repository. It complements, but does not replace, [`CLAUDE.md`](CLAUDE.md).
 If the two documents overlap, follow the stricter rule.
 
-> Reconstructed after the original was accidentally deleted — please replace or
-> edit to match your intent.
-
 ## Start here
 
 `dora-hub` is the collection of reusable [dora](https://github.com/dora-rs/dora)
@@ -14,6 +11,10 @@ nodes (~60), and it also hosts the Dora Hub catalog (`node-index/`). Most nodes
 are Python (built/tested with **uv**, linted with **ruff**, tested with
 **pytest**); some are Rust members of the root Cargo workspace, and a few are
 Rust+Python (maturin) hybrids.
+
+> **Note:** the `node-index/` catalog and its tooling land with the catalog
+> bootstrap (PR #66). Until that merges, the catalog instructions below
+> (`make index-ci`, the "don't hand-edit the catalog" rule) don't yet apply.
 
 **Read [`CLAUDE.md`](CLAUDE.md) first** — it is the canonical reference for the
 repo map, build/test commands, the CI structure, and the pre-commit gates.
@@ -29,8 +30,9 @@ repo map, build/test commands, the CI structure, and the pre-commit gates.
 - **Verify what you change.** `make test-node NODE=<name>` runs exactly what CI
   runs for one node (uv + ruff + pytest, or cargo). For Rust workspace changes,
   `make test-rust` and `make lint`. For `node-index/` changes, `make index-ci`.
-- **Don't hand-edit the catalog.** `node-index/` entries come from
-  `dora hub publish`; published version files are immutable (append-only).
+- **Don't hand-edit the catalog** (once it exists — see the note above).
+  `node-index/` entries come from `dora hub publish`; published version files
+  are immutable (append-only).
 
 ## Before you finish
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`dora-rs/dora-hub` is the **collection of reusable [dora](https://github.com/dora-rs/dora) nodes** — ~60 ready-to-use sensors, models, transforms, and sinks you can drop into a dataflow. Nodes are independently packaged and published (Python to PyPI, Rust to crates.io); a dataflow pulls one in via `pip install dora-<name>` / a `git:` source / or a `hub:` reference.
+
+This repo also hosts the **Dora Hub catalog** (`node-index/`) — the git-backed index that the `dora hub` CLI resolves `hub:` references against (spec: [`docs/plan-node-hub.md`](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md) in `dora-rs/dora`).
+
+Two languages, one repo:
+- **Python nodes** (~55) — `pyproject.toml` + a package dir, built/tested with **uv**, linted with **ruff**, tested with **pytest**.
+- **Rust nodes** (~14) — members of the root **Cargo workspace**; some are Rust+Python (maturin) hybrids.
+
+## Repository Layout
+
+| Path | What |
+|------|------|
+| `node-hub/<name>/` | One node per directory — the active, maintained collection |
+| `node-archive/` | Deprecated nodes, not built or tested in CI |
+| `node-index/` | The Dora Hub catalog (`<ns>/<name>/<version>.yml`); see `node-index/README.md` |
+| `examples/` | End-to-end dataflows exercised by CI (`examples/*/dataflow.yml`) |
+| `tests/` | Workspace-level Rust integration tests |
+| `benches/` | Benchmarks |
+| `schemas/` | JSON schemas for the node-index entry / package format |
+| `scripts/` | Repo tooling (`index-ci/` validators, `test-node.sh`) |
+| `.github/workflows/` | CI (see below) |
+
+### Anatomy of a node
+
+**Python node** (`node-hub/dora-echo/`):
+```
+dora-echo/
+  pyproject.toml          # name = "dora-echo"; [project.scripts] dora-echo = "dora_echo.main:main"
+  dora_echo/__init__.py   # package dir (underscores)
+  dora_echo/main.py       # entrypoint
+  tests/test_dora_echo.py # pytest
+  README.md
+```
+**Packaging convention:** the PyPI dist name, the `[project.scripts]` console-script, and the value a dataflow uses as `path:` are **all the same string** (`dora-echo`). New nodes must keep this 1:1:1 mapping. Lint config lives under `[tool.ruff.lint]` — see the shared baseline in the root `ruff.toml`.
+
+**Rust node** (`node-hub/dora-rerun/`): a `Cargo.toml` workspace member (add it to the root `Cargo.toml` `members`). Rust+Python hybrids also carry a `pyproject.toml` and build a wheel with maturin.
+
+## Build & Test Commands
+
+### Rust workspace
+```bash
+# A few nodes need system libs / are heavy — CI excludes them:
+cargo check  --all --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
+cargo build  --all --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
+cargo test   --all --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
+cargo clippy --all --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
+cargo fmt --all -- --check
+```
+
+### A single node (the inner loop)
+Run exactly what CI runs for one node, locally:
+```bash
+make test-node NODE=dora-echo        # or: scripts/test-node.sh dora-echo
+```
+For a Python node this does `uv venv` + `uv pip install .` + `uv run ruff check .` + `uv run pytest`; for a Rust node, `cargo check/clippy/build/test`. It reuses the same driver CI uses (`.github/workflows/node_hub_test.sh`), so local == CI.
+
+### The node-index catalog
+```bash
+make index-ci                         # schema + append-only validators + unit tests
+# or individually:
+python3 scripts/index-ci/tests/test_index_ci.py
+python3 scripts/index-ci/validate_entries.py
+```
+
+## Pre-commit Quality Gates (MANDATORY)
+
+**Run these before pushing.** Remote CI is a large multi-platform, ~60-node matrix — catching failures locally saves a long round-trip.
+
+1. **For each node you touched:** `make test-node NODE=<name>` (ruff + pytest, or cargo for Rust nodes).
+2. **If you touched Rust workspace code:** `cargo fmt --all -- --check`, then `cargo clippy --all <excludes>`, then `cargo test --all <excludes>`.
+3. **If you touched `node-index/`, `schemas/`, or `scripts/index-ci/`:** `make index-ci`.
+4. **Always:** `typos` (config: `_typos.toml`).
+
+`make qa` runs the repo-wide static gates (ruff on repo Python + rustfmt check + clippy + index-ci + typos) in one go. Use `make test-node NODE=<n>` for the node you changed.
+
+## Remote CI
+
+| Workflow | Scope |
+|----------|-------|
+| `ci.yml` | Rust workspace Check/Build/Test (Linux/macOS/Windows), Clippy, rustfmt, Typos, and example dataflows end-to-end |
+| `node-hub-ci-cd.yml` | Per-node matrix: runs `node_hub_test.sh` for each `node-hub/<folder>` on Linux+macOS; publishes on release |
+| `node-index-ci.yml` | Catalog CI (schema + append-only), **path-scoped to `node-index/**`** — never gates `node-hub/` source |
+| `claude-code.yml` | `@claude` GitHub automation |
+
+## Conventions
+
+- **Adding a node:** see [`CONTRIBUTING.md`](CONTRIBUTING.md) — keep the name 1:1:1 (dist == console-script == `path:`), add Rust nodes to the workspace `members`, include a `tests/` directory.
+- **Rust:** format with `rustfmt` defaults; fix clippy before pushing.
+- **Python:** ruff for lint (baseline in root `ruff.toml`), pytest for tests, **uv** for envs (not bare `pip`).
+- **Publishing to the Hub:** use `dora hub publish` (don't hand-edit `node-index/` entries); published version files are immutable (append-only, enforced by `node-index CI`).
+- Discuss non-trivial changes in a GitHub issue or Discord first; don't fix unrelated warnings in a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This repo also hosts the **Dora Hub catalog** (`node-index/`) — the git-backed index that the `dora hub` CLI resolves `hub:` references against (spec: [`docs/plan-node-hub.md`](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md) in `dora-rs/dora`).
 
+> **Note:** the `node-index/` catalog, its `schemas/`, `scripts/index-ci/`, and the `node-index CI` workflow land with the catalog bootstrap (PR #66). Until that merges, the index sections below don't apply and `make index-ci` is a no-op.
+
 Two languages, one repo:
 - **Python nodes** (~55) — `pyproject.toml` + a package dir, built/tested with **uv**, linted with **ruff**, tested with **pytest**.
 - **Rust nodes** (~14) — members of the root **Cargo workspace**; some are Rust+Python (maturin) hybrids.
@@ -58,7 +60,7 @@ Run exactly what CI runs for one node, locally:
 ```bash
 make test-node NODE=dora-echo        # or: scripts/test-node.sh dora-echo
 ```
-For a Python node this does `uv venv` + `uv pip install .` + `uv run ruff check .` + `uv run pytest`; for a Rust node, `cargo check/clippy/build/test`. It reuses the same driver CI uses (`.github/workflows/node_hub_test.sh`), so local == CI.
+For a Python node this does `uv venv` + `uv pip install .` + `uv run ruff check .` + `uv run pytest`; for a Rust node, `cargo check/clippy/build/test`. A Rust+Python (maturin) hybrid additionally runs a `maturin build --release` (no publish). It reuses the same driver CI uses (`.github/workflows/node_hub_test.sh`), so local == CI.
 
 ### The node-index catalog
 ```bash
@@ -84,7 +86,7 @@ python3 scripts/index-ci/validate_entries.py
 | Workflow | Scope |
 |----------|-------|
 | `ci.yml` | Rust workspace Check/Build/Test (Linux/macOS/Windows), Clippy, rustfmt, Typos, and example dataflows end-to-end |
-| `node-hub-ci-cd.yml` | Per-node matrix: runs `node_hub_test.sh` for each `node-hub/<folder>` on Linux+macOS; publishes on release |
+| `node-hub-ci-cd.yml` | Per-node matrix (`node_hub_test.sh` for each `node-hub/<folder>`). PRs run the lint+test step on Linux only; macOS runs on release/dispatch. Publishes on release |
 | `node-index-ci.yml` | Catalog CI (schema + append-only), **path-scoped to `node-index/**`** — never gates `node-hub/` source |
 | `claude-code.yml` | `@claude` GitHub automation |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,10 @@ on Discord first.
 
 ## Publishing to the Dora Hub
 
+> The `node-index/` catalog and its CI land with the catalog bootstrap (PR #66);
+> this section applies once that merges.
+
 The `node-index/` catalog is produced by the `dora hub publish` CLI — **don't
 hand-edit version entries**. Published version files are immutable (append-only,
 enforced by `node-index CI`); a yank is the one allowed mutation. See
-[`node-index/README.md`](node-index/README.md).
+`node-index/README.md` for the format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to dora-hub
+
+`dora-hub` is the collection of reusable [dora](https://github.com/dora-rs/dora)
+nodes. This guide covers adding/maintaining a node and the checks to run before
+you push. See [`CLAUDE.md`](CLAUDE.md) for the repo map and command reference.
+
+## Adding a node
+
+A node lives in its own directory under `node-hub/<name>/`.
+
+### Python node
+
+```
+node-hub/my-node/
+  pyproject.toml          # see below
+  my_node/__init__.py     # package dir — underscores
+  my_node/main.py         # entrypoint with a main()
+  tests/test_my_node.py   # at least an import/smoke test
+  README.md
+```
+
+`pyproject.toml` must keep the **1:1:1 naming convention** — the PyPI
+distribution name, the `[project.scripts]` console-script, and the string a
+dataflow uses as `path:` are all the same:
+
+```toml
+[project]
+name = "my-node"                       # dist name == path: in a dataflow
+
+[project.scripts]
+my-node = "my_node.main:main"          # console-script == dist name
+
+[tool.ruff.lint]
+extend-select = ["D", "UP", "PERF", "RET", "RSE", "NPY", "N", "I"]  # align with /ruff.toml
+```
+
+- Use **uv** for environments and **pytest** for tests.
+- Keep your node's `[tool.ruff.lint]` aligned with the repo baseline in
+  [`ruff.toml`](ruff.toml).
+- A test that imports `main` and asserts it raises outside a dataflow is the
+  minimum (see `node-hub/dora-echo/tests/`).
+
+### Rust node
+
+Add the crate to the root `Cargo.toml` `members`. Rust+Python hybrids also carry
+a `pyproject.toml` and build a wheel with maturin (the CI driver handles this).
+
+## Testing locally
+
+Run exactly what CI runs for your node:
+
+```bash
+make test-node NODE=my-node        # uv + ruff + pytest, or cargo for a Rust node
+```
+
+The helper neutralizes any active conda/virtualenv so `uv` uses the node's own
+`.venv`. For workspace-wide Rust changes:
+
+```bash
+make test-rust                     # cargo test for the workspace
+make lint                          # ruff (repo tooling) + rustfmt --check + clippy
+```
+
+## Before you push
+
+The remote matrix is large (≈60 nodes × platforms), so check locally first:
+
+1. `make test-node NODE=<name>` for **each node you touched**.
+2. If you changed **Rust workspace** code: `cargo fmt --all -- --check`, `cargo clippy`, `cargo test`.
+3. If you changed **`node-index/`**: `make index-ci`.
+4. `make qa` bundles the static gates (lint + index-ci + typos).
+
+Don't fix unrelated warnings in a PR; discuss non-trivial changes in an issue or
+on Discord first.
+
+## Publishing to the Dora Hub
+
+The `node-index/` catalog is produced by the `dora hub publish` CLI — **don't
+hand-edit version entries**. Published version files are immutable (append-only,
+enforced by `node-index CI`); a yank is the one allowed mutation. See
+[`node-index/README.md`](node-index/README.md).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# dora-hub developer convenience targets. See CLAUDE.md for the full workflow.
+# Rust nodes that need system libs / are heavy are excluded, matching ci.yml.
+RUST_EXCLUDES := --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
+
+.PHONY: help
+help:
+	@echo "dora-hub dev targets:"
+	@echo "  make test-node NODE=<name>   test + lint one node like CI (uv/ruff/pytest, or cargo)"
+	@echo "  make lint                    ruff (repo Python) + rustfmt --check + clippy"
+	@echo "  make fmt                     cargo fmt + ruff format (repo Python)"
+	@echo "  make test-rust               cargo test for the Rust workspace"
+	@echo "  make index-ci                node-index schema + append-only checks"
+	@echo "  make typos                   spell-check (crate-ci/typos)"
+	@echo "  make qa                      pre-commit static gates: lint + index-ci + typos"
+
+.PHONY: test-node
+test-node:
+	@test -n "$(NODE)" || { echo "usage: make test-node NODE=<name>" >&2; exit 2; }
+	scripts/test-node.sh $(NODE)
+
+.PHONY: lint
+lint:
+	ruff check .
+	cargo fmt --all -- --check
+	cargo clippy --all $(RUST_EXCLUDES)
+
+.PHONY: fmt
+fmt:
+	cargo fmt --all
+	ruff format .
+
+.PHONY: test-rust
+test-rust:
+	cargo test --all $(RUST_EXCLUDES)
+
+.PHONY: index-ci
+index-ci:
+	@if [ -d scripts/index-ci ]; then \
+	  python3 scripts/index-ci/tests/test_index_ci.py && \
+	  python3 scripts/index-ci/validate_entries.py; \
+	else echo "index-ci: no node-index/ catalog in this tree — skipping"; fi
+
+.PHONY: typos
+typos:
+	@if command -v typos >/dev/null; then typos; \
+	else echo "typos: not installed (\`cargo install typos-cli\`) — skipping"; fi
+
+.PHONY: qa
+qa: lint index-ci typos
+	@echo "qa: static gates passed"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,32 @@
+# Shared Python lint baseline for dora-hub.
+#
+# This governs repo-level Python (e.g. `scripts/`). Each `node-hub/<name>`
+# carries its own `[tool.ruff.lint]` in its `pyproject.toml` (ruff uses the
+# nearest config) — keep new nodes aligned with the `extend-select` set below so
+# the collection stays consistent.
+
+line-length = 100
+
+# Nodes are linted by their own per-node config in CI (each carries its own
+# [tool.ruff.lint]); this root config governs repo tooling (scripts/). Example,
+# test, and benchmark scripts predate this baseline and are left as-is.
+extend-exclude = ["node-hub", "node-archive", "benches", "examples", "tests"]
+
+[lint]
+extend-select = [
+  "D",    # pydocstyle (docstrings)
+  "UP",   # pyupgrade
+  "PERF", # performance
+  "RET",  # return
+  "RSE",  # raise
+  "NPY",  # numpy
+  "N",    # pep8-naming
+  "I",    # import sorting
+]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.per-file-ignores]
+# Internal tooling and tests aren't published packages — don't force docstrings.
+"scripts/**" = ["D"]

--- a/scripts/test-node.sh
+++ b/scripts/test-node.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Run locally exactly what CI runs for one node (lint + tests, no publish).
+# Run locally exactly what CI runs for one node (build + lint + tests; never publishes).
 #
 #   scripts/test-node.sh <node-name>        e.g. scripts/test-node.sh dora-echo
 #
 # It reuses the same driver CI uses (.github/workflows/node_hub_test.sh) from the
 # node's directory, so "passes locally" means "passes in CI". Python nodes run
-# uv + ruff + pytest; Rust nodes run cargo check/clippy/build/test.
+# uv + ruff + pytest; Rust nodes run cargo check/clippy/build/test; a Rust+Python
+# (maturin) hybrid additionally runs `maturin build --release` (no publish).
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/test-node.sh
+++ b/scripts/test-node.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run locally exactly what CI runs for one node (lint + tests, no publish).
+#
+#   scripts/test-node.sh <node-name>        e.g. scripts/test-node.sh dora-echo
+#
+# It reuses the same driver CI uses (.github/workflows/node_hub_test.sh) from the
+# node's directory, so "passes locally" means "passes in CI". Python nodes run
+# uv + ruff + pytest; Rust nodes run cargo check/clippy/build/test.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node="${1:-}"
+
+if [[ -z "$node" ]]; then
+  echo "usage: $0 <node-name>   (a directory under node-hub/)" >&2
+  echo "nodes:" >&2
+  ls "$repo_root/node-hub" | sed 's/^/  /' >&2
+  exit 2
+fi
+
+node_dir="$repo_root/node-hub/$node"
+if [[ ! -d "$node_dir" ]]; then
+  echo "error: no such node: node-hub/$node" >&2
+  exit 1
+fi
+
+# The driver keys off the current directory and treats an unset GITHUB_ACTIONS as
+# a local run (no disk cleanup). Set GITHUB_EVENT_NAME so its release-publish
+# checks evaluate false instead of tripping `set -u` locally — never "release",
+# so this can't publish.
+export GITHUB_EVENT_NAME="local"
+
+# A locally-active conda/virtualenv hijacks `uv`'s target — it would install the
+# node into the active env instead of the node's own `.venv`, then `uv run` can't
+# find it. Neutralize it so `uv venv` + `uv pip install .` are authoritative.
+unset VIRTUAL_ENV CONDA_PREFIX CONDA_DEFAULT_ENV
+
+echo ">> testing node-hub/$node (local)"
+cd "$node_dir"
+exec bash "$repo_root/.github/workflows/node_hub_test.sh"


### PR DESCRIPTION
## What

Dev-experience foundations for the node collection — a **CLAUDE.md** plus the additive half of the CI/test-infra enhancements we scoped. Mirrors the `dora` repo's structured workflow (documented pre-commit gates, a clear build/test map, a local QA loop) but fit to a polyglot (Python + Rust), per-node collection rather than a single Rust workspace.

**Pure additions** — no existing workflow, driver, or node is modified.

## Contents
- **`CLAUDE.md`** — repo map, node anatomy + the 1:1:1 packaging convention (dist == console-script == `path:`), Rust-workspace + single-node build/test commands, the mandatory pre-commit gates, and the CI structure.
- **`Makefile` + `scripts/test-node.sh`** — `make test-node NODE=<name>` runs *exactly* what CI runs for one node locally (uv + ruff + pytest, or cargo), by reusing the existing `node_hub_test.sh` driver — so "passes locally" means "passes in CI". The helper neutralizes an active conda/virtualenv that would otherwise hijack `uv`'s target env (verified against `dora-echo`: ruff + pytest green). Plus `make lint` / `test-rust` / `index-ci` / `qa`.
- **`ruff.toml`** — the shared Python lint baseline (`extend-select` matching the nodes), governing repo tooling under `scripts/`; each node keeps its own `[tool.ruff.lint]` (ruff uses the nearest config), so this doesn't churn 55 pyprojects.
- **`CONTRIBUTING.md`** — how to add a node (Python + Rust), test locally, and the pre-push checklist.

## Verified
- `make test-node NODE=dora-echo` → ruff "All checks passed" + pytest "1 passed".
- `ruff check .` clean; `make help` / `make index-ci` (graceful skip) behave.

## Follow-ups (the rest of the scoped work)
- **PR B** — the CI rewrite: make `ci.yml` + `node-hub-ci-cd.yml` path-aware so a PR only builds/tests the nodes it changes (today a docs-only PR triggers all ~60), and move the hardcoded skip-lists out of `node_hub_test.sh` into per-node config.

## Merge-order note
`CLAUDE.md` / `CONTRIBUTING.md` reference `node-index/` (the Hub catalog), which lands in the **P2.3 bootstrap #66**. Merge #66 first (or together) so those links resolve; `make index-ci` already degrades gracefully when the catalog isn't present.
