### PR TITLE
ci: build only the nodes a PR changes; per-node skip markers

### DIFF
--- a/.github/workflows/node-hub-ci-cd.yml
+++ b/.github/workflows/node-hub-ci-cd.yml
@@ -59,7 +59,11 @@ jobs:
           git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
           files="$(git diff --name-only "origin/$BASE...HEAD")"
           echo "changed files:"; echo "$files" | sed 's/^/  /'
-          # A change to a shared build input rebuilds every node.
+          # A change to a shared build input rebuilds every node. Nodes are
+          # self-contained today (no cross-node deps). IF a shared local crate
+          # is ever added under node-hub/ that several nodes depend on via
+          # `path = `, add it here too — otherwise a change to it would not
+          # fan out and its dependents would be silently untested.
           if echo "$files" | grep -qE '^(Cargo\.toml|Cargo\.lock|\.github/workflows/(node-hub-ci-cd\.yml|node_hub_test\.sh))$'; then
             echo "shared build input changed -> test all nodes"
             echo "run_all=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/node-hub-ci-cd.yml
+++ b/.github/workflows/node-hub-ci-cd.yml
@@ -26,13 +26,51 @@ jobs:
     name: Find Jobs
     outputs:
       folders: ${{ steps.jobs.outputs.folders }}
+      run_all: ${{ steps.changed.outputs.run_all }}
+      changed: ${{ steps.changed.outputs.changed }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - id: jobs
         uses: kmanimaran/list-folder-action@v4
         with:
           path: node-hub
+
+      # Decide, once, which nodes a PR actually touches. The matrix below stays
+      # full (every node still reports a check), but each node job skips its
+      # heavy build/test steps unless it's in this set — so a PR only builds the
+      # nodes it changes. Non-PR events and shared-input changes fan out to all.
+      - id: changed
+        name: Determine changed nodes
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "event '$EVENT' -> test all nodes"
+            echo "run_all=true" >> "$GITHUB_OUTPUT"
+            echo "changed=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
+          files="$(git diff --name-only "origin/$BASE...HEAD")"
+          echo "changed files:"; echo "$files" | sed 's/^/  /'
+          # A change to a shared build input rebuilds every node.
+          if echo "$files" | grep -qE '^(Cargo\.toml|Cargo\.lock|\.github/workflows/(node-hub-ci-cd\.yml|node_hub_test\.sh))$'; then
+            echo "shared build input changed -> test all nodes"
+            echo "run_all=true" >> "$GITHUB_OUTPUT"
+            echo "changed=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          nodes="$(echo "$files" | sed -nE 's#^node-hub/([^/]+)/.*#\1#p' | sort -u)"
+          json="$(echo "$nodes" | jq -R . | jq -s -c 'map(select(length > 0))')"
+          echo "changed nodes: $json"
+          echo "run_all=false" >> "$GITHUB_OUTPUT"
+          echo "changed=$json" >> "$GITHUB_OUTPUT"
 
   ci:
     runs-on: ${{ matrix.platform }}
@@ -46,20 +84,38 @@ jobs:
         platform: [ubuntu-24.04, macos-14]
         folder: ${{ fromJson(needs.find-jobs.outputs.folders )}}
     steps:
+      # Runs first, before checkout — node-hub/<folder> doesn't exist yet, so it
+      # uses the workspace root. Sets `run=true` when this node should be built.
+      - name: Decide whether this node needs CI
+        id: decide
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        env:
+          RUN_ALL: ${{ needs.find-jobs.outputs.run_all }}
+          CHANGED: ${{ needs.find-jobs.outputs.changed }}
+          FOLDER: ${{ matrix.folder }}
+        run: |
+          if [ "$RUN_ALL" = "true" ] || printf '%s' "$CHANGED" | jq -e --arg f "$FOLDER" 'any(. == $f)' >/dev/null; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "node-hub/$FOLDER unchanged in this PR — skipping its build/tests"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
-        if: runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
+        if: steps.decide.outputs.run == 'true' && (runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')))
         uses: actions/checkout@v4
         with:
           submodules: true # Make sure to check out the sub-module
 
       - name: Update submodule
-        if: runner.os == 'Linux'
+        if: steps.decide.outputs.run == 'true' && runner.os == 'Linux'
         run: |
           git submodule update --init --recursive
           git submodule update --remote --recursive
 
       - name: Install system-level dependencies
-        if: runner.os == 'Linux'
+        if: steps.decide.outputs.run == 'true' && runner.os == 'Linux'
         run: |
           sudo apt update
           sudo apt-get install portaudio19-dev
@@ -73,23 +129,24 @@ jobs:
           sudo apt install g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
 
       - name: Install system-level dependencies for MacOS
-        if: runner.os == 'MacOS' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')))
+        if: steps.decide.outputs.run == 'true' && runner.os == 'MacOS' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')))
         run: |
           brew install portaudio
           brew install dav1d nasm
 
       - name: Set up Python
-        if: runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
+        if: steps.decide.outputs.run == 'true' && (runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')))
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
 
       - name: Install the latest version of uv
+        if: steps.decide.outputs.run == 'true'
         uses: astral-sh/setup-uv@v5
 
       - name: Run Linting and Tests
         ## Run Linting and testing only on Mac for release workflows.
-        if: runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
+        if: steps.decide.outputs.run == 'true' && (runner.os == 'Linux' || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')))
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASS }}

--- a/.github/workflows/node_hub_test.sh
+++ b/.github/workflows/node_hub_test.sh
@@ -4,11 +4,10 @@ set -euo
 # Check if we are running in a GitHub Actions environment
 CI=${GITHUB_ACTIONS:-false}
 
-# List of ignored modules 
-ignored_folders=("dora-parler" "dora-opus" "dora-internvl" "dora-magma")
-
-# Skip test
-skip_test_folders=("dora-internvl" "dora-parler" "dora-keyboard" "dora-microphone" "terminal-input" "dora-magma" "dora-phi4" "dora-qwen2-5-vl")
+# CI skip is declared per-node, next to the node, rather than in lists here:
+#   node-hub/<node>/.ci-skip    -> the node can't be built/tested on CI at all
+#   node-hub/<node>/.skip-test  -> build/install the node but skip its pytest
+# (a short reason belongs in each marker file).
 
 # Get current working directory
 dir=$(pwd)
@@ -38,8 +37,8 @@ if [[ " ${large_node[@]} " =~ " ${base_dir} " ]] && [[ "$CI" == "true" ]]; then
 fi
 
 # Check if the directory name is in the ignored list
-if [[ " ${ignored_folders[@]} " =~ " ${base_dir} " ]]; then
-    echo "Skipping $base_dir as we cannot test it on the CI..."
+if [[ -f ".ci-skip" ]]; then
+    echo "Skipping $base_dir (.ci-skip present) as we cannot test it on the CI..."
 else
     # IF job is mixed rust-python job and is on linux 
     if [[ -f "Cargo.toml" && -f "pyproject.toml" &&  "$(uname)" = "Linux" ]]; then
@@ -107,9 +106,9 @@ else
             echo "CI: Running Linting in $dir..."
             uv run ruff check .
             echo "CI: Running Pytest in $dir..."
-            # Skip test for some folders
-            if [[ " ${skip_test_folders[@]} " =~ " ${base_dir} " ]]; then
-                echo "Skipping tests for $base_dir..."
+            # Skip pytest when the node declares `.skip-test`
+            if [[ -f ".skip-test" ]]; then
+                echo "Skipping tests for $base_dir (.skip-test present)..."
             else
                 uv run pytest
             fi

--- a/node-hub/dora-internvl/.ci-skip
+++ b/node-hub/dora-internvl/.ci-skip
@@ -1,0 +1,1 @@
+# CI cannot build/test this node (large model / heavy deps). Remove to re-enable.

--- a/node-hub/dora-keyboard/.skip-test
+++ b/node-hub/dora-keyboard/.skip-test
@@ -1,0 +1,1 @@
+# Tests need interactive input / hardware not available on CI; the node still builds.

--- a/node-hub/dora-microphone/.skip-test
+++ b/node-hub/dora-microphone/.skip-test
@@ -1,0 +1,1 @@
+# Tests need a microphone/hardware not available on CI; the node still builds.

--- a/node-hub/dora-parler/.ci-skip
+++ b/node-hub/dora-parler/.ci-skip
@@ -1,0 +1,1 @@
+# CI cannot build/test this node (large model / heavy deps). Remove to re-enable.

--- a/node-hub/dora-qwen2-5-vl/.skip-test
+++ b/node-hub/dora-qwen2-5-vl/.skip-test
@@ -1,0 +1,1 @@
+# Tests need a large model download not feasible on CI; the node still builds.

--- a/node-hub/terminal-input/.skip-test
+++ b/node-hub/terminal-input/.skip-test
@@ -1,0 +1,1 @@
+# Tests need an interactive terminal not available on CI; the node still builds.


### PR DESCRIPTION
## What

The CI/test-infra rewrite (enhancements 2 + 4 of the dev-infra work; companion to #67). Two changes:

### 1. Path-aware node matrix — only build the nodes a PR changes
`node-hub-ci-cd.yml` rebuilt **all ~60 nodes on every PR**, even docs-only ones. Now:
- `find-jobs` computes which `node-hub/<x>` folders the PR touches, and **fans out to all nodes** when a shared build input changes (root `Cargo.toml`/`Cargo.lock`, the workflow, or `node_hub_test.sh`). Non-PR events (push to main / release / `workflow_dispatch`) always run everything.
- The **matrix stays full** — every node still reports its check — so this is safe for required-status-checks (no "skipped required check" hanging merges). Each node job runs a cheap `decide` step first and **skips its heavy steps** (checkout, submodules, apt installs, build, tests) unless it's in the changed set. A docs-only PR now builds **zero** nodes; a one-node PR builds one.
- Conservative by design: anything it can't cleanly scope falls back to *run all*.

### 2. Decentralize the skip-lists
The hardcoded `ignored_folders` / `skip_test_folders` arrays in `node_hub_test.sh` are replaced by per-node markers, so a node's skip status lives **with the node** and is self-documenting:
- `node-hub/<node>/.ci-skip` — can't be built/tested on CI at all.
- `node-hub/<node>/.skip-test` — build/install the node but skip its `pytest`.

Migrated the existing entries that still have a node directory (`.ci-skip`: dora-parler, dora-internvl; `.skip-test`: dora-keyboard, dora-microphone, terminal-input, dora-qwen2-5-vl).

## Verified
- `node-hub-ci-cd.yml` is valid YAML; `node_hub_test.sh` passes `bash -n`.
- Locally validated the detection: changed-node extraction → correct JSON; `decide` membership → correct true/false; shared-input fan-out (Cargo.toml/lock, workflows) → run-all; docs-only diff → empty set (all skip).
- I can't exercise GitHub Actions logic locally — **this PR changes shared inputs, so it triggers the full-matrix path**, which exercises the new `decide`/skip code across all nodes on the PR's own run. Please eyeball that run.

## Note / further work
A bigger reduction (shrinking the matrix to only the changed folders + a summary gate job) would also drop the ~120 short job allocations a docs PR still makes — but it requires updating branch protection to the gate's check name, so I left it out to avoid touching your merge gating. Happy to do it if you want.
