### PR TITLE
ci: fail-fast off so one broken node doesn't cancel the whole matrix

### DIFF
--- a/.github/workflows/node-hub-ci-cd.yml
+++ b/.github/workflows/node-hub-ci-cd.yml
@@ -83,7 +83,9 @@ jobs:
       run:
         working-directory: node-hub/${{ matrix.folder }}
     strategy:
-      fail-fast: ${{ github.event_name != 'workflow_dispatch' && !(github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')) }}
+      # Nodes are independent — one broken node must not cancel the other ~60
+      # (and turn the whole run red). Report each node's status on its own.
+      fail-fast: false
       matrix:
         platform: [ubuntu-24.04, macos-14]
         folder: ${{ fromJson(needs.find-jobs.outputs.folders )}}


### PR DESCRIPTION
## What

Stops one broken node from turning the entire node-hub matrix red.

## Diagnosis

The matrix was red on every shared/push build. It looked like a systemic **macOS** failure (all 62 macOS jobs "failed"), but those were **`cancelled`, not failed** — `fail-fast: true` cancels the entire ~120-job matrix (both platforms) the instant one node fails. A handful of nodes genuinely fail, and fail-fast amplified that into an all-red run.

With `fail-fast: false`, the latest run shows the true state: **117 green / 7 red**.

## Fix

- **`fail-fast: false`** — nodes are independent; one broken node must not cancel the other ~60. Each node reports its own status. (Combined with the path-aware matrix from #68, a normal PR only runs the nodes it changes, so it stays green.)

## Why no Python bump here

I initially also bumped the test driver to Python 3.12, but reverted it: a **global** pin can't fix the broken nodes — they have **conflicting** needs:
- `lerobot`-based nodes (`dora-policy-inference`, `dora-dataset-record`) need **≥3.12**, and their pyproject `requires-python` (`>=3.10`) is too loose, so uv rejects them regardless of the venv version.
- `dora-pyrealsense` needs **≤3.11** — `pyrealsense2` has no 3.12 wheel (3.12 *broke* it).

So those are per-node fixes, tracked separately, not bundled into this CI change.

## The 7 genuinely-broken nodes (independent of this PR)
| node | cause |
|------|-------|
| dora-policy-inference, dora-dataset-record | `requires-python >=3.10` but `lerobot` needs `>=3.12` |
| dora-mujoco | `requires-python >=3.8` but `robot-descriptions` needs `>=3.10` |
| dora-pyrealsense | `pyrealsense2` has no Python-3.12 wheel (needs the driver to stay ≤3.11) |
| dora-sam2 | build fails: `No module named 'setuptools'` (build backend) |
| dora-dav1d | maturin: `libdav1d` needs `manylinux_2_34`, build uses `manylinux_2_28` |
| dora-teleop-xr | 14 `ruff` lint errors |
