### PR TITLE
fix(node-hub): un-break dora-mujoco and dora-teleop-xr

### DIFF
--- a/node-hub/dora-mujoco/dora_mujoco/main.py
+++ b/node-hub/dora-mujoco/dora_mujoco/main.py
@@ -9,7 +9,7 @@ import json
 import os
 from pathlib import Path
 import time
-from typing import Dict, Any
+from typing import Any
 from robot_descriptions.loaders.mujoco import load_robot_description
 
 
@@ -119,7 +119,7 @@ class MuJoCoSimulator:
             "sensordata": self.data.sensordata.copy() if self.model.nsensor > 0 else np.array([])  # Sensor readings
         }
     
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         """Get current simulation state."""
         return self.state_data.copy()
 

--- a/node-hub/dora-mujoco/pyproject.toml
+++ b/node-hub/dora-mujoco/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "Your Name", email = "email@email.com" }]
 description = "MuJoCo simulation node for Dora"
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 dependencies = [
   "dora-rs >= 0.3.9",

--- a/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
+++ b/node-hub/dora-teleop-xr/dora_teleop_xr/main.py
@@ -20,6 +20,7 @@ from teleop_xr.messages import XRState
 
 
 def load_robot_class(class_path: str):
+    """Import and return the robot class named by a ``module:ClassName`` path."""
     if ":" not in class_path:
         raise ValueError(
             f"Invalid ROBOT_CLASS format: '{class_path}'. Expected 'module:ClassName'"
@@ -30,23 +31,32 @@ def load_robot_class(class_path: str):
 
 
 def get_robot_joint_order(robot_class) -> tuple[str, ...] | None:
+    """Return the robot's default rerun joint order, or None if unspecified."""
     if hasattr(robot_class, "DEFAULT_RERUN_JOINT_ORDER"):
         return robot_class.DEFAULT_RERUN_JOINT_ORDER
     return None
 
 
 class JointNamesProvider(Protocol):
+    """Protocol for robots that expose their actuated joint names."""
+
     @property
-    def actuated_joint_names(self) -> list[str]: ...
+    def actuated_joint_names(self) -> list[str]:
+        """The robot's actuated joint names, in actuation order."""
+        ...
 
 
 class IKStateContainer(TypedDict):
+    """Shared IK state passed between the node loop and the worker thread."""
+
     q: NDArray[np.float32]
     active: bool
     xr_state: XRState | None
 
 
 class IKWorker(threading.Thread):
+    """Background thread that runs the IK controller on incoming XR state."""
+
     def __init__(
         self,
         controller: IKController,
@@ -54,6 +64,7 @@ class IKWorker(threading.Thread):
         teleop: Teleop,
         state_container: IKStateContainer,
     ):
+        """Set up the worker with its controller, robot, teleop, and shared state."""
         super().__init__(daemon=True)
         self.controller = controller
         self.robot = robot
@@ -65,10 +76,12 @@ class IKWorker(threading.Thread):
         self.teleop_loop = None
 
     def update_state(self, state: XRState):
+        """Record the latest XR state and wake the worker."""
         self.latest_xr_state = state
         self.new_state_event.set()
 
     def set_teleop_loop(self, loop: asyncio.AbstractEventLoop):
+        """Bind the teleop asyncio loop once, publishing the initial joint state."""
         if self.teleop_loop is None:
             self.teleop_loop = loop
             if "q" in self.state_container:
@@ -84,6 +97,7 @@ class IKWorker(threading.Thread):
                 )
 
     def run(self):
+        """Solve IK whenever new XR state arrives and publish joint updates."""
         while self.running:
             if not self.new_state_event.wait(timeout=0.1):
                 continue
@@ -128,6 +142,7 @@ class IKWorker(threading.Thread):
 
 
 def pose_to_array(pose):
+    """Flatten a pose into an ``[x, y, z, qx, qy, qz, qw]`` float32 array, or None."""
     if not pose or not pose.position or not pose.orientation:
         return None
     pos = pose.position
@@ -151,6 +166,7 @@ def reorder_joint_state_for_rerun(
     q_current: NDArray[np.float32],
     joint_order: tuple[str, ...] | None,
 ) -> NDArray[np.float32]:
+    """Reorder a joint-state vector into the robot's rerun URDF joint order."""
     if joint_order is None:
         return q_current
 
@@ -173,6 +189,7 @@ def reorder_joint_state_for_rerun(
 
 
 def main():
+    """Run the node: bridge XR teleop input to robot IK and pose/joint outputs."""
     jax.config.update("jax_platform_name", "cpu")
 
     robot_class_path = os.environ.get(

--- a/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
+++ b/node-hub/dora-teleop-xr/tests/test_dora_teleop_xr.py
@@ -41,7 +41,7 @@ def test_so101_robot_init():
 
 def test_reorder_joint_state_for_rerun_so101_order():
     """Test joint state reordering for SO101 URDF traversal order."""
-    SO101_ORDER = (
+    so101_order = (
         "shoulder_pan",
         "shoulder_lift",
         "elbow_flex",
@@ -59,7 +59,7 @@ def test_reorder_joint_state_for_rerun_so101_order():
         ]
 
     q_current = np.array([1, 2, 3, 4, 5], dtype=np.float32)
-    reordered = reorder_joint_state_for_rerun(MockRobot(), q_current, SO101_ORDER)
+    reordered = reorder_joint_state_for_rerun(MockRobot(), q_current, so101_order)
 
     expected = np.array([5, 4, 3, 2, 1], dtype=np.float32)
     assert np.allclose(reordered, expected)


### PR DESCRIPTION
## What

Fixes two of the broken nodes surfaced by `fail-fast: false` (#69):

| node | was failing because | fix |
|------|--------------------|-----|
| **dora-mujoco** | `requires-python >=3.8` was wider than its deps support (`robot-descriptions` needs `>=3.10`) → uv refused to resolve; once that was fixed, 2 ruff `UP` errors (`typing.Dict`) surfaced | bump `requires-python` → `>=3.10`, and `typing.Dict` → `dict`. Verified locally: resolves + installs (18 pkgs) and `ruff check` clean |
| **dora-teleop-xr** | 14 ruff errors (13 missing docstrings + 1 constant-naming) | added meaningful docstrings + lowercased the test-local constant; `ruff check` clean (and it already passed CI on a prior run) |

Path-aware CI (#68) builds exactly these two nodes, so the run is the verification.

## Deferred (separate PRs)
- **dora-dav1d** — maturin's wheel-repair fails because the extension links the system `libdav1d` (glibc 2.32/2.34 > `manylinux_2_28`). Building `libdav1d` from source is the fix, but it needs CI iteration (a Linux maturin build I can't reproduce locally), so it gets its own PR. **Left untouched here — no `.ci-skip`**, so dav1d stays broken-but-loud rather than silently suppressed on releases (per review).
- **dora-policy-inference / dora-dataset-record** — need a Python-3.12 venv (lerobot) vs `dora-pyrealsense` (no 3.12 wheel); wants per-node Python selection in the driver.
- **dora-sam2** — `no-build-isolation` / setuptools build issue.
