### PR TITLE
ci: pick a per-node Python from requires-python (fixes the lerobot nodes)

### DIFF
--- a/.github/workflows/node_hub_test.sh
+++ b/.github/workflows/node_hub_test.sh
@@ -101,7 +101,17 @@ else
         else
             if [ -f "$dir/pyproject.toml" ]; then
             echo "CI: Installing in $dir..."
-            uv venv --seed -p 3.11
+            # Pick a Python this node supports. Default to 3.11 (what the
+            # collection has tested on); honor a HIGHER floor from
+            # requires-python (e.g. lerobot-based nodes need >=3.12). Never go
+            # below 3.11, so nodes that still ship 3.11-only wheels keep working.
+            pyver=3.11
+            req_low=$(grep -E '^[[:space:]]*requires-python' pyproject.toml | grep -oE '3\.[0-9]+' | head -1)
+            if [ -n "$req_low" ] && [ "${req_low#3.}" -gt 11 ] 2>/dev/null; then
+                pyver="$req_low"
+            fi
+            echo "CI: using Python $pyver (requires-python: ${req_low:-unset})"
+            uv venv --seed -p "$pyver"
             uv pip install .
             echo "CI: Running Linting in $dir..."
             uv run ruff check .

--- a/node-hub/dora-dataset-record/pyproject.toml
+++ b/node-hub/dora-dataset-record/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "Shashwat Patil", email = "email@email.com" }]
 description = "dora-dataset-record"
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 dependencies = ["dora-rs >= 0.3.9", "pyarrow", "lerobot[train]"]
 

--- a/node-hub/dora-policy-inference/pyproject.toml
+++ b/node-hub/dora-policy-inference/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "Shashwat Patil", email = "email@email.com" }]
 description = "dora-policy-inference"
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 dependencies = ["dora-rs >= 0.3.9", "pyarrow", "lerobot"]
 


### PR DESCRIPTION
## What

Replaces the hard-pinned `uv venv -p 3.11` in the node test driver with a **per-node** Python choice, fixing the version conflict that no single global pin can solve:
- `dora-policy-inference` / `dora-dataset-record` need **≥3.12** (lerobot)
- `dora-pyrealsense` needs **≤3.11** (`pyrealsense2` has no 3.12 wheel)

## How

The driver now picks the venv Python from each node's `requires-python`:
- **default 3.11** — what the collection has tested on, so the ~55 currently-passing nodes are unchanged
- **honor a higher floor** — a node declaring `>=3.12` gets 3.12
- **never below 3.11** — so 3.11-only-wheel nodes (pyrealsense) keep working

Plus bump `requires-python` to `>=3.12` on the two lerobot nodes so the picker selects 3.12 for them.

Verified locally:

| node | requires-python | picked |
|------|----------------|--------|
| dora-policy-inference, dora-dataset-record | `>=3.12` | **3.12** |
| dora-pyrealsense | `>=3.8` | 3.11 |
| dora-mujoco, dora-echo (typical) | `>=3.10`/`>=3.8` | 3.11 |

`dora-policy-inference` resolves cleanly on a 3.12 venv (53 packages).

## Verification

This touches `node_hub_test.sh` (a shared input), so CI runs the **full matrix** — which is what we want here: it confirms the 2 lerobot nodes now build on 3.12, `dora-pyrealsense` still builds on 3.11, and the other ~55 nodes are unaffected. (`fail-fast: false` shows each independently.)

Remaining deferred: `dora-dav1d` (from-source maturin build), `dora-sam2` (no-build-isolation / setuptools).
