### PR TITLE
Hub P2.3 (3/3): auto-merge bot + owner-identity (closes #66 HIGH-1/HIGH-2)

### DIFF
--- a/.github/workflows/index-auto-merge.yml
+++ b/.github/workflows/index-auto-merge.yml
@@ -1,0 +1,72 @@
+name: index auto-merge
+
+# Trusted-context auto-merge bot for the node-index/ catalog (Hub spec §7.5).
+#
+# pull_request_target runs in the BASE repo's context, so it has a write token
+# AND, critically, lets us run the enforcement scripts from the BASE ref rather
+# than the PR's own (possibly-neutered) copy — closing the self-neutering hole.
+# We check out the PR head only as DATA: the trusted scripts `yaml.safe_load` it,
+# we never execute any PR-provided code (no PR build/install/script runs), so
+# this is not a "pwn request".
+#
+# It auto-merges only a routine publish (decide_auto_merge.py: version files in
+# an existing namespace, owner-authored, nothing that needs human review).
+# Everything else is left untouched for a human; node-index CI (the required
+# check) still gates correctness.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'node-index/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base ref (source of the trusted scripts + schemas)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+      - name: Stash trusted enforcement code outside the workspace
+        run: |
+          mkdir -p "$RUNNER_TEMP/trusted"
+          cp -r scripts schemas "$RUNNER_TEMP/trusted/"
+      - name: Checkout PR head (data only — never executed)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Make the base commit reachable for merge-base
+        run: git fetch --no-tags origin "${{ github.event.pull_request.base.sha }}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: pip install jsonschema pyyaml
+      - name: Run trusted checks and auto-merge routine publishes
+        env:
+          T: ${{ runner.temp }}/trusted/scripts/index-ci
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR: ${{ github.event.pull_request.number }}
+          # validate the PR's catalog data with the TRUSTED schemas
+          DORA_INDEX_ROOT: ${{ github.workspace }}/node-index
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python3 "$T/validate_entries.py"; v=$?
+          python3 "$T/check_append_only.py" --base "$BASE_SHA"; a=$?
+          python3 "$T/decide_auto_merge.py" --author "$AUTHOR" --base "$BASE_SHA"; d=$?
+          echo "verdict: validate=$v append-only=$a decide=$d"
+          if [ "$v" = 0 ] && [ "$a" = 0 ] && [ "$d" = 0 ]; then
+            echo "routine publish by an owner -> enabling auto-merge"
+            gh pr merge "$PR" --squash --auto \
+              || echo "could not enable auto-merge (is 'Allow auto-merge' enabled on the repo?)"
+          else
+            echo "not auto-merging; left for a human reviewer (node-index CI still gates correctness)"
+          fi

--- a/node-index/README.md
+++ b/node-index/README.md
@@ -43,7 +43,7 @@ dora hub publish            # validates the manifest, resolves the commit pin,
 ```
 
 Then open a PR adding the `node-index/<ns>/<name>/<version>.yml` file. CI
-validates it and (once the auto-merge bot lands) merges it without a review
+validates it and the auto-merge bot merges a routine publish without a review
 queue — publishing latency is CI latency.
 
 ## Rules (machine-enforced by `node-index CI`)
@@ -56,21 +56,28 @@ queue — publishing latency is CI latency.
   [`schemas/node-index-entry.schema.json`](../schemas/node-index-entry.schema.json);
   `source.rev` must be a full 40-/64-hex commit, and the directory must match
   `manifest.namespace` / `manifest.name`.
-- **Namespaces.** A new namespace claim (`package.yml`) for a
-  [reserved name](../scripts/index-ci/reserved_namespaces.txt) needs an index
-  admin. Owner-identity and confusable-name checks land with the governance
-  workstream (P2.3 PR 2).
+- **Namespaces.** A new namespace claim is screened against the reserved list
+  (needs an index admin) and a confusable/edit-distance check (needs human
+  review), and always gets a human reviewer — see [`POLICY.md`](POLICY.md).
+- **Owner identity.** The auto-merge bot only merges a version published by an
+  **owner** of its namespace (the `package.yml` OWNERS list, read from the base
+  branch — a PR can't add itself as an owner and self-approve). Non-owner
+  publishes, OWNERS changes, new namespaces, and anything touching the policy /
+  CI / scripts are left for a human.
 
 These checks run **only** on `node-index/**` — they never gate the
 human-reviewed `node-hub/` source path.
 
-## Status: not yet a trust boundary
+## Trust boundary
 
-This bootstrap (P2.3 PR 1) lands the schema, path/pin validation, and the
-append-only rule. It does **not** yet verify *who* may publish: the CI proves an
-entry is well-formed and immutable, not that the PR author owns the namespace.
-Until the governance workstream (PR 2) and the auto-merge bot (PR 3) land — the
-bot enforces the `package.yml` OWNERS list and reserved-namespace claims — a
-`node-index/` entry must be treated as *unverified provenance*, not an
-authoritative mapping. Resolving `hub:` references should stay opt-in/manual
-until then.
+The auto-merge bot (`.github/workflows/index-auto-merge.yml`) runs the
+enforcement scripts from the **base branch** against a PR's catalog *data*
+(never the PR's own copy of the scripts), so a PR can't neuter its own gate.
+Combined with the owner-identity check, a merged `node-index/` entry has
+verified provenance: it was published by a namespace owner, is schema-valid,
+pins an immutable commit, and never overwrote an existing version.
+
+Two repo settings make this airtight and should be enabled by an admin:
+**branch protection** requiring the `node-index CI` check + code-owner review on
+`scripts/index-ci/**`, `schemas/**`, and `.github/workflows/**`; and **"Allow
+auto-merge"** so the bot can queue a merge behind those required checks.

--- a/scripts/index-ci/decide_auto_merge.py
+++ b/scripts/index-ci/decide_auto_merge.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Decide whether a `node-index/` PR may auto-merge (Hub P2.3, spec §7.5).
+
+The auto-merge bot runs this from the **trusted base checkout** (never the PR's
+own copy of these scripts) against the PR's `node-index/` content. It returns
+MERGE only for a *routine publish*:
+
+  - the PR touches **only** version files (`node-index/<ns>/<name>/<semver>.yml`),
+    never `package.yml`/OWNERS, the policy, the CI, or the scripts/schemas
+    themselves (those are human-review categories, §7.5);
+  - every change is an add or an append-only edit (no delete/rename — the
+    append-only gate enforces the edit *content*, this just refuses the status);
+  - no **new namespace** is claimed (new namespaces always get a human, §7.4);
+  - every touched entry is authored by an **owner** of its namespace, where the
+    OWNERS list is read from the *base* `package.yml` (not the PR's — a PR must
+    not be able to add itself as an owner and self-approve).
+
+Anything else is HOLD — left for a human reviewer. Schema/pin validation and the
+append-only *content* rule run as separate trusted hard gates in the bot job.
+
+Usage: decide_auto_merge.py --author <login> [--base <ref>]
+  Prints `MERGE` and exits 0 when auto-mergeable; prints `HOLD: <reasons>` and
+  exits 1 otherwise. Org-membership lookups use `gh api` (needs GH_TOKEN).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_namespace import git, namespaces_at  # noqa: E402  (trusted siblings)
+
+# node-index/<ns>/<name>/<semver>.yml — the only path an auto-merge may touch.
+_VERSION_FILE_RE = re.compile(
+    r"^node-index/[^/]+/[^/]+/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:[-+][0-9A-Za-z.-]+)*\.yml$"
+)
+
+
+def changed_files(base: str) -> list[tuple[str, str]]:
+    """(status, path) for files changed in merge-base(base, HEAD)..HEAD."""
+    merge_base = git("merge-base", base, "HEAD").strip()
+    out = git("diff", "--name-status", "-M", merge_base, "HEAD")
+    changes: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        cols = line.split("\t")
+        # rename/copy: "<R|C><score>\told\tnew" — new path is the last column
+        changes.append((cols[0][0], cols[-1]))
+    return changes
+
+
+def is_version_file(path: str) -> bool:
+    return bool(_VERSION_FILE_RE.match(path))
+
+
+def owners_at(ref: str, ns: str, name: str) -> list[str]:
+    """OWNERS list from the package.yml at `ref` (empty if absent/malformed)."""
+    try:
+        text = git("show", f"{ref}:node-index/{ns}/{name}/package.yml")
+    except subprocess.CalledProcessError:
+        return []
+    doc = yaml.safe_load(text)
+    owners = doc.get("owners") if isinstance(doc, dict) else None
+    return [o for o in owners if isinstance(o, str)] if isinstance(owners, list) else []
+
+
+def is_authorized(author: str, owners: list[str], is_member) -> bool:
+    """Author owns the namespace directly, or via an org in the OWNERS list."""
+    if author in owners:
+        return True
+    return any(is_member(o, author) for o in owners if o and o != author)
+
+
+def gh_is_member(org: str, user: str) -> bool:
+    """True if `user` is a public member of org `org` (404/non-org -> False)."""
+    r = subprocess.run(
+        ["gh", "api", f"/orgs/{org}/members/{user}", "--silent"],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0
+
+
+def decide(author: str, base: str, is_member=gh_is_member) -> list[str]:
+    """Return a list of HOLD reasons; empty list means auto-mergeable."""
+    merge_base = git("merge-base", base, "HEAD").strip()
+    files = changed_files(base)
+    reasons: list[str] = []
+
+    # path + status guard: only added/appended version files may auto-merge
+    bad_paths = sorted({p for _, p in files if not is_version_file(p)})
+    if bad_paths:
+        reasons.append(
+            "touches files that need human review (§7.5): " + ", ".join(bad_paths)
+        )
+    bad_status = sorted({p for s, p in files if s not in ("A", "M")})
+    if bad_status:
+        reasons.append("deletes/renames a published file: " + ", ".join(bad_status))
+
+    # new-namespace guard (§7.4): a new namespace always gets a human
+    new_ns = namespaces_at("HEAD") - namespaces_at(merge_base)
+    if new_ns:
+        reasons.append("claims new namespace(s): " + ", ".join(sorted(new_ns)))
+
+    # owner guard (§7.5): every touched version entry must be owner-authored,
+    # against the OWNERS list as it exists in the base (not the PR)
+    for _, path in files:
+        if not is_version_file(path):
+            continue
+        _, ns, name, _ = path.split("/")
+        owners = owners_at(merge_base, ns, name)
+        if not owners:
+            reasons.append(f"{path}: no owners on the base package.yml")
+        elif not is_authorized(author, owners, is_member):
+            reasons.append(f"{path}: @{author} is not an owner of {ns}/{name}")
+
+    return reasons
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    default_base = (
+        f"origin/{os.environ['GITHUB_BASE_REF']}"
+        if os.environ.get("GITHUB_BASE_REF")
+        else "origin/main"
+    )
+    ap.add_argument("--author", required=True)
+    ap.add_argument("--base", default=default_base)
+    args = ap.parse_args()
+
+    try:
+        reasons = decide(args.author, args.base)
+    except subprocess.CalledProcessError as e:
+        print(f"HOLD: git inspection failed: {e.stderr.strip()}")
+        return 1
+
+    if reasons:
+        print("HOLD: " + "; ".join(reasons))
+        return 1
+    print("MERGE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/index-ci/decide_auto_merge.py
+++ b/scripts/index-ci/decide_auto_merge.py
@@ -90,8 +90,13 @@ def gh_is_member(org: str, user: str) -> bool:
 
 
 def decide(author: str, base: str, is_member=gh_is_member) -> list[str]:
-    """Return a list of HOLD reasons; empty list means auto-mergeable."""
-    merge_base = git("merge-base", base, "HEAD").strip()
+    """Return a list of HOLD reasons; empty list means auto-mergeable.
+
+    All authorization reads (owners, existing namespaces) use `base` — the base
+    *tip* — never `merge-base(base, HEAD)`. The PR chooses its own merge-base
+    (its branch point), so a former owner could branch from an old commit where
+    they were still listed and self-approve. `changed_files` still enumerates
+    the PR's own edits via merge-base; that only widens the set (fail-safe)."""
     files = changed_files(base)
     reasons: list[str] = []
 
@@ -105,18 +110,21 @@ def decide(author: str, base: str, is_member=gh_is_member) -> list[str]:
     if bad_status:
         reasons.append("deletes/renames a published file: " + ", ".join(bad_status))
 
-    # new-namespace guard (§7.4): a new namespace always gets a human
-    new_ns = namespaces_at("HEAD") - namespaces_at(merge_base)
+    # new-namespace guard (§7.4): a new namespace always gets a human. Compare
+    # against the base tip so resurrecting a namespace deleted on base (but
+    # present at the branch point) is still flagged new.
+    new_ns = namespaces_at("HEAD") - namespaces_at(base)
     if new_ns:
         reasons.append("claims new namespace(s): " + ", ".join(sorted(new_ns)))
 
     # owner guard (§7.5): every touched version entry must be owner-authored,
-    # against the OWNERS list as it exists in the base (not the PR)
+    # against the OWNERS list as it exists on the base tip (not the PR, and not
+    # the branch point)
     for _, path in files:
         if not is_version_file(path):
             continue
         _, ns, name, _ = path.split("/")
-        owners = owners_at(merge_base, ns, name)
+        owners = owners_at(base, ns, name)
         if not owners:
             reasons.append(f"{path}: no owners on the base package.yml")
         elif not is_authorized(author, owners, is_member):

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -23,6 +23,7 @@ os.environ["DORA_INDEX_ROOT"] = str(FIXTURES)
 
 import check_append_only as cao  # noqa: E402
 import check_namespace as cns  # noqa: E402
+import decide_auto_merge as dam  # noqa: E402
 import validate_entries as ve  # noqa: E402
 
 PASSED = 0
@@ -233,10 +234,92 @@ def test_namespace_screening() -> None:
     check("levenshtein rn vs m is 2", cns.levenshtein("acrne", "acme") == 2)
 
 
+def test_decide_auto_merge() -> None:
+    import subprocess as sp
+    import tempfile
+
+    print("decide_auto_merge (path/owner guards):")
+    check("version file accepted", dam.is_version_file("node-index/acme/widget/1.2.3.yml"))
+    check("prerelease semver accepted", dam.is_version_file("node-index/acme/widget/1.0.0-rc.1.yml"))
+    check("package.yml is not a version file", not dam.is_version_file("node-index/acme/widget/package.yml"))
+    check("nested path rejected", not dam.is_version_file("node-index/acme/widget/sub/1.0.0.yml"))
+    check("non-semver rejected", not dam.is_version_file("node-index/acme/widget/latest.yml"))
+    check("outside node-index rejected", not dam.is_version_file("node-hub/acme/main.py"))
+
+    member = {("acme-org", "alice")}
+    is_member = lambda org, user: (org, user) in member  # noqa: E731
+    check("direct owner authorized", dam.is_authorized("alice", ["alice"], is_member))
+    check("non-owner rejected", not dam.is_authorized("mallory", ["alice"], is_member))
+    check("org-member authorized", dam.is_authorized("alice", ["acme-org"], is_member))
+    check("non-member of owner-org rejected", not dam.is_authorized("bob", ["acme-org"], is_member))
+
+    print("decide_auto_merge (real two-commit repo):")
+    no_org = lambda org, user: False  # noqa: E731
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        }
+
+        def g(*a: str) -> None:
+            sp.run(["git", *a], cwd=repo, env=env, check=True, capture_output=True)
+
+        def commit(msg: str) -> None:
+            g("add", "-A")
+            g("commit", "-qm", msg)
+
+        entry = "manifest: {}\nsource: {git: g, rev: r}\n"
+        g("init", "-q", "-b", "main")
+        pkg = repo / "node-index" / "acme" / "widget"
+        pkg.mkdir(parents=True)
+        (pkg / "package.yml").write_text("owners:\n  - alice\n")
+        (pkg / "1.0.0.yml").write_text(entry)
+        commit("base")
+        base = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, env=env, capture_output=True, text=True
+        ).stdout.strip()
+
+        saved = os.getcwd()
+        os.chdir(repo)
+        try:
+            # routine publish by the owner -> MERGE
+            (pkg / "1.1.0.yml").write_text(entry)
+            commit("publish 1.1.0")
+            check("owner publish -> MERGE", dam.decide("alice", base, no_org) == [])
+            check(
+                "non-owner publish -> HOLD",
+                any("not an owner" in r for r in dam.decide("mallory", base, no_org)),
+            )
+
+            # new namespace claim -> HOLD (new ns + a non-version package.yml)
+            g("checkout", "-q", base)
+            g("checkout", "-q", "-b", "newns")
+            newpkg = repo / "node-index" / "other" / "thing"
+            newpkg.mkdir(parents=True)
+            (newpkg / "package.yml").write_text("owners:\n  - alice\n")
+            (newpkg / "0.1.0.yml").write_text(entry)
+            commit("new namespace")
+            holds = dam.decide("alice", base, no_org)
+            check("new namespace -> HOLD", any("new namespace" in r for r in holds))
+
+            # editing OWNERS/package.yml -> HOLD (non-version path)
+            g("checkout", "-q", base)
+            g("checkout", "-q", "-b", "owners")
+            (pkg / "package.yml").write_text("owners:\n  - alice\n  - mallory\n")
+            commit("add owner")
+            holds = dam.decide("alice", base, no_org)
+            check("OWNERS edit -> HOLD", any("human review" in r for r in holds))
+        finally:
+            os.chdir(saved)
+
+
 if __name__ == "__main__":
     test_validate()
     test_append_only()
     test_namespace_screening()
+    test_decide_auto_merge()
     test_subdir_no_traversal()
     test_empty_binary_rejected()
     test_symlink_rejected()

--- a/scripts/index-ci/tests/test_index_ci.py
+++ b/scripts/index-ci/tests/test_index_ci.py
@@ -311,6 +311,32 @@ def test_decide_auto_merge() -> None:
             commit("add owner")
             holds = dam.decide("alice", base, no_org)
             check("OWNERS edit -> HOLD", any("human review" in r for r in holds))
+
+            # a FORMER owner branching from an old commit where they were still
+            # listed must HOLD: authorization reads the base tip, not the
+            # attacker-chosen merge-base (CRITICAL-1 regression)
+            g("checkout", "-q", "main")
+            hist = repo / "node-index" / "hist" / "tool"
+            hist.mkdir(parents=True)
+            (hist / "package.yml").write_text("owners:\n  - mallory\n")
+            (hist / "1.0.0.yml").write_text(entry)
+            commit("hist: mallory owns")
+            old = sp.run(
+                ["git", "rev-parse", "HEAD"], cwd=repo, env=env,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            (hist / "package.yml").write_text("owners:\n  - alice\n")
+            commit("hist: transferred to alice")
+            new_tip = sp.run(
+                ["git", "rev-parse", "HEAD"], cwd=repo, env=env,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            g("checkout", "-q", old)
+            g("checkout", "-q", "-b", "hist-attack")
+            (hist / "2.0.0.yml").write_text(entry)
+            commit("hist: mallory republishes from the old branch point")
+            holds = dam.decide("mallory", new_tip, no_org)
+            check("former owner from old commit -> HOLD", any("not an owner" in r for r in holds))
         finally:
             os.chdir(saved)
 


### PR DESCRIPTION
The capstone of P2.3 governance (after #66, #72): a **trusted-context auto-merge bot** that merges routine publishes without a review queue, and closes the two trust-boundary findings from the #66 review.

## What this adds

- **`scripts/index-ci/decide_auto_merge.py`** — the MERGE/HOLD verdict. Auto-merge fires **only** for a routine publish:
  - the PR touches **only** version files (`node-index/<ns>/<name>/<semver>.yml`) — never `package.yml`/OWNERS, policy, CI, or the scripts/schemas;
  - every change is an add or append-only edit (no delete/rename);
  - **no new namespace** is claimed (those always get a human, §7.4 / `review_tier`);
  - every touched entry is authored by an **owner** of its namespace.
  - Anything else → **HOLD** for a human.
- **`.github/workflows/index-auto-merge.yml`** — the bot, on `pull_request_target`. On a full pass it enables GitHub auto-merge (`--squash --auto`), so branch protection's required checks still gate the actual merge.

## Closes the #66 review items

- **HIGH-1 (self-neutering)** — the bot copies the enforcement scripts + schemas from the **base ref**, then checks out the PR head **as data only** (`yaml.safe_load`, never executed — no PR build/install/script runs). A PR can no longer edit `check_*.py` to neuter its own gate. `pull_request_target` also always runs the workflow from the base, so a PR can't edit the bot itself.
- **HIGH-2 (owner identity)** — now enforced: the author must be in the namespace's OWNERS list (direct, or a public member of an org in the list, via `gh api`). Crucially, OWNERS is read from the **base** `package.yml`, so a PR can't add itself as an owner and self-approve (and the path-guard HOLDs any `package.yml` edit regardless).

## Security model (why `pull_request_target` is safe here)

`pull_request_target` is dangerous only if you execute PR-provided code. This workflow never does: it runs trusted base scripts that parse PR YAML as data. No `pip install`/build of PR content, no PR script invocation, `yaml.safe_load` only.

## Repo settings to enable (admin, one-time)

- **Branch protection** on `main`: require the `node-index CI` check + code-owner review for `scripts/index-ci/**`, `schemas/**`, `.github/workflows/**`.
- **"Allow auto-merge"** in repo settings, so the bot can queue a merge behind the required checks.

## Test plan

- `python3 scripts/index-ci/tests/test_index_ci.py` — **57 checks**. A real two-commit git repo proves: owner-publish→MERGE, non-owner→HOLD, new-namespace→HOLD, OWNERS-edit→HOLD; plus path-guard and owner/org-membership unit cases.
- `make index-ci` passes; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
