### PR TITLE
feat(node-hub): Hub migration batch 2 — 10 nodes (manifests + READMEs)

### DIFF
--- a/node-hub/dora-distil-whisper/README.md
+++ b/node-hub/dora-distil-whisper/README.md
@@ -1,28 +1,55 @@
-# Dora Whisper Node for transforming speech to text
+# dora-distil-whisper
 
-## YAML Specification
+Transcribes (or translates) speech audio to text using a Whisper model — `mlx-whisper` on macOS, a HuggingFace `transformers` automatic-speech-recognition pipeline on every other platform.
 
-This node is supposed to be used as follows:
+## Behavior
+
+`dora-distil-whisper` connects as a dora node and, for each input event:
+
+- If the input id contains `text_noise`, the value is stored as noise text (parentheses/brackets stripped) and subtracted from later transcriptions to avoid echo; the noise filter expires after a few seconds.
+- Otherwise the value is treated as audio (Arrow array → numpy) and transcribed. If the previous result ended with `...`, the new audio is concatenated onto the cached audio first.
+
+After transcription it post-processes the text:
+
+- Results matching a built-in `BAD_SENTENCES` list (hallucination fillers) are discarded.
+- Repeated runs of words/characters are trimmed (`cut_repetition`).
+- Stored `text_noise` words are removed.
+- Empty, `.`-only, or `...`-ending results are not emitted; a `...`-ending result is cached so the next audio chunk is appended to it.
+
+On macOS the `transformers`/torch path is skipped entirely and `mlx-whisper` (`mlx-community/whisper-large-v3-turbo`) is used; `TRANSLATE` is not applied on this path.
+
+## Inputs
+
+- `input` — audio samples to transcribe (Arrow array of floats). Any input id that does **not** contain `text_noise` is treated as audio.
+- `text_noise` — text to subtract from subsequent transcriptions (e.g. the assistant's own spoken output). Optional.
+
+## Outputs
+
+- `text` — the transcribed/translated string (Arrow string array) with metadata `{language, primitive: text}`.
+- `speech_started` — emitted alongside `text` carrying the same string; signals a finalized utterance.
+
+## Environment variables
+
+- `TARGET_LANGUAGE` (default `english`) — language for transcription, and target language when translating.
+- `TRANSLATE` (default `False`) — when `True`/`true`, translate into `TARGET_LANGUAGE` instead of transcribing. Ignored on macOS.
+- `MODEL_NAME_OR_PATH` (default `openai/whisper-large-v3-turbo`) — HuggingFace model id or local path for the non-macOS pipeline. (macOS always uses `mlx-community/whisper-large-v3-turbo`.)
+- `USE_MODELSCOPE_HUB` (default `False`) — when `True`/`true` (non-macOS), download the model from ModelScope instead of HuggingFace.
+
+## Usage
 
 ```yaml
-- id: dora-distil-whisper
-  build: pip install dora-distil-whisper
-  path: dora-distil-whisper
-  inputs:
-    input: dora-vad/audio
-  outputs:
-    - text
-  env:
-    TARGET_LANGUAGE: english
+nodes:
+  - id: dora-distil-whisper
+    hub: dora-distil-whisper@^0.5
+    inputs:
+      input: some-vad/audio
+    outputs:
+      - text
+      - speech_started
 ```
 
-## Examples
+## Build
 
-- speech to text
-  - github: https://github.com/dora-rs/dora-hub/blob/main/examples/speech-to-text
-- vision language model
-  - github: https://github.com/dora-rs/dora-hub/blob/main/examples/vlm
-
-## License
-
-Dora-whisper's code and model weights are released under the MIT License
+```bash
+pip install .
+```

--- a/node-hub/dora-distil-whisper/dora-node.yml
+++ b/node-hub/dora-distil-whisper/dora-node.yml
@@ -1,0 +1,46 @@
+apiVersion: 1
+name: dora-distil-whisper
+namespace: dora-rs
+description: Transcribes (or translates) speech audio to text using a Whisper model (mlx-whisper on macOS, transformers pipeline elsewhere).
+categories: [speech, ml-inference]
+keywords: [whisper, asr, speech-to-text, transcription, stt]
+runtime: python
+entrypoint: dora-distil-whisper
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  input:
+    required: true
+    description: Audio samples to transcribe, as an Arrow array of floats. Any input whose id does not contain "text_noise" is treated as audio. Buffered across messages when the previous transcription ended with "...".
+  text_noise:
+    required: false
+    description: Text to subtract from subsequent transcriptions (e.g. the assistant's own spoken output) to avoid echo; parentheses and brackets are stripped. Expires after a few seconds.
+outputs:
+  text:
+    description: Transcribed (or translated) text as an Arrow string array, with metadata {language, primitive=text}. Suppressed for empty/known-bad/repetitive results or text ending in "..." (which is instead buffered).
+  speech_started:
+    description: Emitted alongside text with the same transcribed string; signals that a finalized utterance was produced.
+env:
+  TARGET_LANGUAGE:
+    default: english
+    description: Language used for transcription and for the target language when translating.
+  TRANSLATE:
+    type: bool
+    default: false
+    description: When true, translate the transcription into TARGET_LANGUAGE instead of transcribing in the source language. Ignored on macOS (mlx path always transcribes).
+  MODEL_NAME_OR_PATH:
+    default: openai/whisper-large-v3-turbo
+    description: HuggingFace model id or local path for the transformers pipeline (non-macOS). On macOS the mlx-community/whisper-large-v3-turbo model is always used.
+  USE_MODELSCOPE_HUB:
+    type: bool
+    default: false
+    description: When true (non-macOS), download MODEL_NAME_OR_PATH from ModelScope via snapshot_download instead of HuggingFace.
+example: |
+  - id: dora-distil-whisper
+    hub: dora-distil-whisper@^0.5
+    inputs:
+      input: some-vad/audio
+    outputs:
+      - text
+      - speech_started

--- a/node-hub/dora-keyboard/README.md
+++ b/node-hub/dora-keyboard/README.md
@@ -1,3 +1,46 @@
-# Dora Node for listening to keyboard input.
+# dora-keyboard
 
-Send char only in the `char` output stream, as string, on press.
+Keyboard listener source — emits the character of each printable key as it is
+pressed.
+
+## Behavior
+
+`dora-keyboard` connects as a dora node and listens to the system keyboard via
+`pynput`. On every key **press** event, if the key has a printable character it
+sends that character on the `char` output as a single-element UTF-8 string array
+(metadata `{"primitive": "text"}`). Non-printable keys (modifiers, arrows, etc.)
+produce no output.
+
+It uses `node.next()` only as a liveness check: if it detects that the dora
+input stream has closed, the listen loop exits. It does not consume or react to
+any specific input id.
+
+## Inputs
+
+None — it is a source. (The node polls the dora event stream only to detect
+shutdown, not to read named inputs.)
+
+## Outputs
+
+- `char`: the character of a printable key on press, as a single-element UTF-8
+  string array.
+
+## Environment variables
+
+None.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-keyboard
+    hub: dora-keyboard@^0.5
+    outputs:
+      - char
+```
+
+## Build
+
+```bash
+pip install .
+```

--- a/node-hub/dora-keyboard/dora-node.yml
+++ b/node-hub/dora-keyboard/dora-node.yml
@@ -1,0 +1,19 @@
+apiVersion: 1
+name: dora-keyboard
+namespace: dora-rs
+description: Keyboard listener source — emits the character of each printable key as it is pressed.
+categories: [sensor]
+keywords: [keyboard, input, key, source, pynput]
+runtime: python
+entrypoint: dora-keyboard
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+outputs:
+  char:
+    description: The character of a printable key on press, as a single-element UTF-8 string array (primitive=text metadata).
+example: |
+  - id: dora-keyboard
+    hub: dora-keyboard@^0.5
+    outputs:
+      - char

--- a/node-hub/dora-kokoro-tts/README.md
+++ b/node-hub/dora-kokoro-tts/README.md
@@ -1,38 +1,53 @@
 # dora-kokoro-tts
 
-## Getting started
+Text-to-speech using Kokoro — converts text input into synthesized audio output.
 
-- Install it with pip:
+## Behavior
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
+On startup the node loads a Kokoro `KPipeline` (model from `REPO_ID`, language
+from `LANGUAGE`) and warms it up with a short utterance using `VOICE`.
+
+For each `text` input event it:
+
+- Strips any `<tool_call>...</tool_call>` sections from the text (skipping the
+  event entirely if nothing remains).
+- Splits the remaining text on punctuation (`。 , . ， ? ! :`) into chunks.
+- Per chunk, auto-detects Chinese characters and switches the pipeline
+  `lang_code` to `"z"` for Chinese text (or back to `LANGUAGE` otherwise).
+- Synthesizes each chunk at speed 1.2 and emits the resulting audio.
+
+## Inputs
+
+- `text` — UTF-8 text to synthesize into speech (first element of the Arrow
+  array is read).
+
+## Outputs
+
+- `audio` — synthesized speech as a float Arrow array, emitted once per
+  synthesized chunk. Output metadata carries `sample_rate: 24000`.
+
+## Environment variables
+
+- `REPO_ID` — Hugging Face repo id of the Kokoro model. Default
+  `hexgrad/Kokoro-82M`.
+- `LANGUAGE` — default Kokoro `lang_code` (e.g. `a` for English). The node
+  auto-switches to `z` for Chinese text. Default `a`.
+- `VOICE` — Kokoro voice id used for synthesis. Default `af_heart`.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-kokoro-tts
+    hub: dora-kokoro-tts@^0.5
+    inputs:
+      text: some-llm/text
+    outputs:
+      - audio
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-uv run ruff check . --fix
+pip install .
 ```
-
-- Lint with ruff:
-
-```bash
-uv run ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-uv run pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-kokoro-tts's code are released under the MIT License

--- a/node-hub/dora-kokoro-tts/dora-node.yml
+++ b/node-hub/dora-kokoro-tts/dora-node.yml
@@ -1,0 +1,35 @@
+apiVersion: 1
+name: dora-kokoro-tts
+namespace: dora-rs
+description: Text-to-speech using Kokoro — converts text input into synthesized audio output.
+categories: [speech]
+keywords: [tts, text-to-speech, kokoro, speech, audio]
+runtime: python
+entrypoint: dora-kokoro-tts
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  text:
+    required: true
+    description: Text to synthesize into speech. Content inside <tool_call>...</tool_call> tags is stripped, and the remaining text is split on punctuation before synthesis.
+outputs:
+  audio:
+    description: Synthesized speech as a float Arrow array, emitted per sentence chunk with sample_rate=24000 in the output metadata.
+env:
+  REPO_ID:
+    default: hexgrad/Kokoro-82M
+    description: Hugging Face repo id of the Kokoro model to load.
+  LANGUAGE:
+    default: a
+    description: Default Kokoro lang_code (e.g. "a" for English); auto-switches to "z" for Chinese text.
+  VOICE:
+    default: af_heart
+    description: Kokoro voice id used for synthesis.
+example: |
+  - id: dora-kokoro-tts
+    hub: dora-kokoro-tts@^0.5
+    inputs:
+      text: some-llm/text
+    outputs:
+      - audio

--- a/node-hub/dora-mediapipe/README.md
+++ b/node-hub/dora-mediapipe/README.md
@@ -1,40 +1,56 @@
 # dora-mediapipe
 
-## Getting started
+MediaPipe pose estimation — turns RGB image frames into 2D (and optional depth-derived 3D) body landmarks.
 
-- Install it with uv:
+## Behavior
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
+`dora-mediapipe` connects as a dora node and runs Google MediaPipe Pose on
+incoming image frames. For each input whose id contains `image`, it decodes the
+frame (`bgr8`, `rgb8`, or encoded `jpeg`/`jpg`/`jpe`/`bmp`/`webp`/`png`), runs
+pose estimation, and emits the detected landmarks as flattened `(x, y)` pixel
+coordinates on `points2d`. If no landmarks are found it prints
+`No pose landmarks detected.`
+
+If an input whose id contains `depth` has been received, its frame and
+`focal_length`/`resolution` metadata are cached and used to additionally lift
+each landmark into a 3D coordinate, emitted on `points3d`. Without a prior depth
+input, only `points2d` is produced.
+
+## Inputs
+
+- **image** (required) — RGB/BGR or encoded image frame; matched by substring,
+  so any input id containing `image` qualifies. Requires `encoding`, `width`,
+  and `height` metadata.
+- **depth** (optional) — depth frame; matched by substring (id containing
+  `depth`). Requires `encoding`, `width`, `height`, `focal_length`, and
+  `resolution` metadata.
+
+## Outputs
+
+- **points2d** — flattened `(x, y)` pixel coordinates of the detected pose
+  landmarks.
+- **points3d** — flattened `(x, y, z)` 3D coordinates of the landmarks, emitted
+  only after a depth input has been received.
+
+## Environment variables
+
+None.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-mediapipe
+    hub: dora-mediapipe@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - points2d
+      - points3d
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-uv pip install ruff
-uv run ruff check . --fix
+pip install .
 ```
-
-- Lint with ruff:
-
-```bash
-uv run ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-uv pip install pytest
-uv run pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-mediapipe's code are released under the MIT License

--- a/node-hub/dora-mediapipe/README.md
+++ b/node-hub/dora-mediapipe/README.md
@@ -44,6 +44,7 @@ nodes:
     hub: dora-mediapipe@^0.5
     inputs:
       image: camera/image
+      depth: camera/depth      # required for the points3d output
     outputs:
       - points2d
       - points3d

--- a/node-hub/dora-mediapipe/dora-node.yml
+++ b/node-hub/dora-mediapipe/dora-node.yml
@@ -1,0 +1,31 @@
+apiVersion: 1
+name: dora-mediapipe
+namespace: dora-rs
+description: MediaPipe pose estimation — turns RGB image frames into 2D (and optional depth-derived 3D) body landmarks.
+categories: [ml-inference]
+keywords: [mediapipe, pose, landmarks, vision, image]
+runtime: python
+entrypoint: dora-mediapipe
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  image:
+    required: true
+    description: RGB/BGR or encoded (jpeg/png/bmp/webp) image frame with width/height/encoding metadata; pose landmarks are extracted from it.
+  depth:
+    required: false
+    description: Depth frame (with focal_length and resolution metadata) used to lift detected landmarks into 3D coordinates.
+outputs:
+  points2d:
+    description: Flattened (x, y) pixel coordinates of the detected pose landmarks.
+  points3d:
+    description: Flattened (x, y, z) 3D coordinates of the pose landmarks, emitted only when a depth input has been received.
+example: |
+  - id: dora-mediapipe
+    hub: dora-mediapipe@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - points2d
+      - points3d

--- a/node-hub/dora-mediapipe/dora-node.yml
+++ b/node-hub/dora-mediapipe/dora-node.yml
@@ -26,6 +26,7 @@ example: |
     hub: dora-mediapipe@^0.5
     inputs:
       image: camera/image
+      depth: camera/depth      # required for the points3d output
     outputs:
       - points2d
       - points3d

--- a/node-hub/dora-piper/README.md
+++ b/node-hub/dora-piper/README.md
@@ -30,7 +30,9 @@ leader arm is connected.
 
 - `joint_action` — target joint positions (7 floats: 6 joints + gripper). Ignored in teach mode.
 - `eef_action` — target end-effector pose (7 floats: X/Y/Z/RX/RY/RZ + gripper). Ignored in teach mode.
-- any other input id triggers a one-shot read of the current arm state (see Outputs).
+- `tick` — state-poll trigger: any input that is not `joint_action`/`eef_action`
+  makes the node read and emit the current arm state. Wire a timer here (e.g.
+  `dora/timer/millis/20`) to stream `jointstate`/`pose`/`gripper`.
 
 ## Outputs
 
@@ -54,6 +56,7 @@ nodes:
     hub: dora-piper@^0.5
     inputs:
       joint_action: some-controller/action
+      tick: dora/timer/millis/20      # poll arm state at 50Hz
     outputs:
       - jointstate
       - pose

--- a/node-hub/dora-piper/README.md
+++ b/node-hub/dora-piper/README.md
@@ -1,9 +1,67 @@
-# Dora Node (Experimental) to communicate with Agilex Piper SDK
+# dora-piper
 
-This node is used to communicate with piper.
+Dora node (experimental) to drive an AgileX Piper robot arm via the `piper_sdk` CAN interface.
 
-Make sure to follow both the setup script and installation script from https://github.com/agilexrobotics/piper_sdk
+## Behavior
 
-# To setup the arm
+On startup the node opens the CAN port (`C_PiperInterface(CAN_BUS).ConnectPort()`).
+Unless `TEACH_MODE` is set, it enables the arm (`EnableArm`), waits up to 5s for all
+six motors to report enabled, zeroes the joints and gripper, then enters the event loop.
 
-Make sure that the can bus is activated for both arm and leader arms are not connected.
+For each input event:
+
+- **`joint_action`** — interprets the value as 7 floats (6 joint positions in radians +
+  gripper) and applies them via `JointCtrl` / `GripperCtrl`. Skipped in teach mode and
+  rate-limited to ~20Hz.
+- **`eef_action`** — interprets the value as 7 floats (end-effector X/Y/Z, RX/RY/RZ +
+  gripper) and applies them via `EndPoseCtrl` / `GripperCtrl`. Skipped in teach mode and
+  rate-limited to ~20Hz.
+- **any other input id** — treated as a state-poll trigger: reads the arm joint, end-pose,
+  and gripper messages from the SDK and emits the `jointstate`, `pose`, and `gripper`
+  outputs.
+
+On `STOP` (unless teach mode) it zeroes the joints and gripper, waits 5s, and exits.
+
+Make sure to follow the setup and installation steps from
+https://github.com/agilexrobotics/piper_sdk, that the CAN bus is activated, and that no
+leader arm is connected.
+
+## Inputs
+
+- `joint_action` — target joint positions (7 floats: 6 joints + gripper). Ignored in teach mode.
+- `eef_action` — target end-effector pose (7 floats: X/Y/Z/RX/RY/RZ + gripper). Ignored in teach mode.
+- any other input id triggers a one-shot read of the current arm state (see Outputs).
+
+## Outputs
+
+- `jointstate` — current arm joint state as 7 float32 values (6 joints in radians + gripper opening).
+- `pose` — current end-effector pose as 6 float32 values (X/Y/Z in meters, RX/RY/RZ in radians).
+- `gripper` — current gripper opening as a single float32.
+
+All three are emitted together when a state-poll input (any id other than
+`joint_action` / `eef_action`) is received.
+
+## Environment variables
+
+- `CAN_BUS` — CAN bus interface name passed to `C_PiperInterface` (default: empty string, uses the SDK default).
+- `TEACH_MODE` — when `True`/`true`, the arm is not enabled and command inputs are ignored; used to read state while hand-guiding the arm (default: `False`).
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-piper
+    hub: dora-piper@^0.5
+    inputs:
+      joint_action: some-controller/action
+    outputs:
+      - jointstate
+      - pose
+      - gripper
+```
+
+## Build
+
+```bash
+pip install .
+```

--- a/node-hub/dora-piper/dora-node.yml
+++ b/node-hub/dora-piper/dora-node.yml
@@ -1,0 +1,42 @@
+apiVersion: 1
+name: dora-piper
+namespace: dora-rs
+description: Drive an AgileX Piper robot arm via the piper_sdk CAN interface — accept joint/end-effector commands and emit arm joint, pose, and gripper state.
+categories: [robot]
+keywords: [piper, agilex, arm, robot, actuator, can]
+runtime: python
+entrypoint: dora-piper
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  joint_action:
+    required: false
+    description: Target joint positions (7 float values — 6 joints + gripper, in radians/meters) applied via JointCtrl/GripperCtrl. Ignored in teach mode. Rate-limited to 20Hz.
+  eef_action:
+    required: false
+    description: Target end-effector pose (7 float values — X/Y/Z/RX/RY/RZ + gripper) applied via EndPoseCtrl/GripperCtrl. Ignored in teach mode. Rate-limited to 20Hz.
+outputs:
+  jointstate:
+    description: Current arm joint state — 7 float32 values (6 joints in radians + gripper opening). Emitted when any input other than joint_action/eef_action is received.
+  pose:
+    description: Current end-effector pose — 6 float32 values (X/Y/Z in meters, RX/RY/RZ in radians). Emitted alongside jointstate on a state-poll input.
+  gripper:
+    description: Current gripper opening as a single float32. Emitted alongside jointstate on a state-poll input.
+env:
+  CAN_BUS:
+    default: ""
+    description: CAN bus interface name passed to C_PiperInterface (empty string uses the SDK default).
+  TEACH_MODE:
+    type: bool
+    default: false
+    description: When true, the arm is not enabled and command inputs are ignored — used to read state while hand-guiding the arm.
+example: |
+  - id: dora-piper
+    hub: dora-piper@^0.5
+    inputs:
+      joint_action: some-controller/action
+    outputs:
+      - jointstate
+      - pose
+      - gripper

--- a/node-hub/dora-piper/dora-node.yml
+++ b/node-hub/dora-piper/dora-node.yml
@@ -16,6 +16,9 @@ inputs:
   eef_action:
     required: false
     description: Target end-effector pose (7 float values — X/Y/Z/RX/RY/RZ + gripper) applied via EndPoseCtrl/GripperCtrl. Ignored in teach mode. Rate-limited to 20Hz.
+  tick:
+    required: false
+    description: State-poll trigger — on any input that is not joint_action/eef_action, the node reads and emits the current jointstate/pose/gripper. Wire a timer here (e.g. dora/timer/millis/20) to stream arm state.
 outputs:
   jointstate:
     description: Current arm joint state — 7 float32 values (6 joints in radians + gripper opening). Emitted when any input other than joint_action/eef_action is received.
@@ -36,6 +39,7 @@ example: |
     hub: dora-piper@^0.5
     inputs:
       joint_action: some-controller/action
+      tick: dora/timer/millis/20      # poll arm state at 50Hz
     outputs:
       - jointstate
       - pose

--- a/node-hub/dora-pyaudio/README.md
+++ b/node-hub/dora-pyaudio/README.md
@@ -1,49 +1,47 @@
 # dora-pyaudio
 
-## Getting started
+Plays received audio samples to the system speakers using PyAudio.
 
-- (MacOS) Install `portaudio`
+## Behavior
 
-```bash
-brew install portaudio
+`dora-pyaudio` is an audio playback sink. It connects as a dora node and, on
+each `audio` input event, plays the samples to the default output device via
+PyAudio (`stream.write`). Floating-point arrays are scaled by 70000 and cast to
+int16; int16 arrays are played as-is. Playback uses 1 channel (mono) at the
+`paInt16` format. The sample rate is taken from the input message's
+`sample_rate` metadata, falling back to the `SAMPLE_RATE` environment variable.
+
+It produces no outputs.
+
+Requires `portaudio` to be installed on the system: `brew install portaudio`
+(macOS) or `sudo apt-get install portaudio19-dev python-all-dev` (Linux).
+
+## Inputs
+
+- `audio` — audio samples to play, as an Arrow array of int16 or floating-point
+  values. Optional `sample_rate` metadata selects the playback rate.
+
+## Outputs
+
+None — it is a sink.
+
+## Environment variables
+
+- `SAMPLE_RATE` (int, default `16000`) — default playback sample rate in Hz,
+  used when an input message omits `sample_rate` metadata.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-pyaudio
+    hub: dora-pyaudio@^0.5
+    inputs:
+      audio: some-node/audio
 ```
 
-- (Linux) Install `portaudio`
+## Build
 
 ```bash
-sudo apt-get install portaudio19-dev python-all-dev
+pip install .
 ```
-
-- Install it with pip:
-
-```bash
-pip install -e .
-```
-
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
-
-```bash
-ruff check . --fix
-```
-
-- Lint with ruff:
-
-```bash
-ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-pyaudio's code are released under the MIT License

--- a/node-hub/dora-pyaudio/dora-node.yml
+++ b/node-hub/dora-pyaudio/dora-node.yml
@@ -1,0 +1,25 @@
+apiVersion: 1
+name: dora-pyaudio
+namespace: dora-rs
+description: Plays received audio samples to the system speakers using PyAudio.
+categories: [actuator, speech]
+keywords: [pyaudio, audio, playback, speaker]
+runtime: python
+entrypoint: dora-pyaudio
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  audio:
+    required: true
+    description: Audio samples to play; an Arrow array of int16 or floating-point values. Per-message metadata may carry sample_rate (falls back to SAMPLE_RATE).
+env:
+  SAMPLE_RATE:
+    type: int
+    default: 16000
+    description: Default playback sample rate in Hz, used when an input message omits sample_rate metadata.
+example: |
+  - id: dora-pyaudio
+    hub: dora-pyaudio@^0.5
+    inputs:
+      audio: some-node/audio

--- a/node-hub/dora-pyrealsense/README.md
+++ b/node-hub/dora-pyrealsense/README.md
@@ -1,88 +1,83 @@
-# Dora Node for capturing video with PyRealSense
+# dora-pyrealsense
 
-This node is used to capture video from a camera using PyRealsense.
+Captures aligned RGB color and depth frames from an Intel RealSense camera.
 
-# Installation
+## Behavior
 
-Make sure to use realsense udev config at https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md
+On startup the node queries for connected RealSense devices and raises a
+`ConnectionError` if none are found. It opens the device selected by
+`DEVICE_SERIAL` (or the default device) and enables a color stream
+(`rgb8`) and a depth stream (`z16`) at `IMAGE_WIDTH` x `IMAGE_HEIGHT`, 30 FPS.
+Depth frames are aligned to the color stream via `rs.align`.
 
-You can try, the following:
+On each `tick` input it waits for a frame set, aligns it, and:
 
-```bash
-wget https://raw.githubusercontent.com/IntelRealSense/librealsense/refs/heads/master/scripts/setup_udev_rules.sh
+- Optionally flips the color frame (`FLIP` = `VERTICAL` / `HORIZONTAL` / `BOTH`).
+- Encodes the color frame per `ENCODING` (`rgb8` passthrough, `bgr8` color
+  conversion, or OpenCV image encoding for `jpeg`/`jpg`/`jpe`/`bmp`/`webp`/`png`).
+- Sends the color frame on `image` with metadata (`encoding`, `width`,
+  `height`, `resolution` = RGB principal point, `focal_length`, `timestamp`).
+- Zeros depth values above 5000, then sends the depth frame on `depth` as
+  `mono16`, reusing the color frame metadata.
 
-mkdir config
-cd config
-wget https://raw.githubusercontent.com/IntelRealSense/librealsense/master/config/99-realsense-libusb.rules
+When the `CI` environment variable is `true`, the node runs for only 10 seconds.
 
-cd ..
+## Inputs
 
-chmod +x setup_udev_rules.sh
-```
+- `tick`: trigger to capture one aligned color + depth frame.
 
-# YAML
+## Outputs
 
-```yaml
-- id: opencv-video-capture
-  build: pip install ../../opencv-video-capture
-  path: opencv-video-capture
-  inputs:
-    tick: dora/timer/millis/16 # try to capture at 60fps
-  outputs:
-    - image: # the captured image
+- `image`: color frame as a flattened Arrow array (`pa.array(frame.ravel())`).
+  Metadata: `encoding`, `width`, `height`, `resolution`, `focal_length`,
+  `timestamp`.
+- `depth`: aligned depth frame (`mono16`, values > 5000 zeroed) as a flattened
+  Arrow array, sharing the color frame metadata.
 
-  env:
-    PATH: 0 # optional, default is 0
-
-    IMAGE_WIDTH: 640 # optional, default is video capture width
-    IMAGE_HEIGHT: 480 # optional, default is video capture height
-```
-
-# Inputs
-
-- `tick`: empty Arrow array to trigger the capture
-
-# Outputs
-
-- `image`: an arrow array containing the captured image
+Decoding the `image` output:
 
 ```Python
-## Image data
-image_data: UInt8Array # Example: pa.array(img.ravel())
-metadata = {
-  "width": 640,
-  "height": 480,
-  "encoding": str, # bgr8, rgb8
-}
-
-## Example
-node.send_output(
-  image_data, {"width": 640, "height": 480, "encoding": "bgr8"}
-  )
-
-## Decoding
 storage = event["value"]
-
 metadata = event["metadata"]
 encoding = metadata["encoding"]
 width = metadata["width"]
 height = metadata["height"]
 
-if encoding == "bgr8":
+if encoding in ["rgb8", "bgr8"]:
     channels = 3
-    storage_type = np.uint8
-
-frame = (
-    storage.to_numpy()
-    .astype(storage_type)
-    .reshape((height, width, channels))
-)
+    frame = (
+        storage.to_numpy()
+        .astype(np.uint8)
+        .reshape((height, width, channels))
+    )
 ```
 
-## Examples
+## Environment variables
 
-Check example at [examples/python-dataflow](examples/python-dataflow)
+- `FLIP`: flip the color frame; one of `VERTICAL`, `HORIZONTAL`, `BOTH` (empty disables). Default empty.
+- `DEVICE_SERIAL`: serial number of the RealSense device to open (empty selects the default device). Default empty.
+- `IMAGE_HEIGHT`: requested stream height in pixels. Default `480`.
+- `IMAGE_WIDTH`: requested stream width in pixels. Default `640`.
+- `ENCODING`: color output encoding; `rgb8`, `bgr8`, or an OpenCV-encoded format (`jpeg`, `jpg`, `jpe`, `bmp`, `webp`, `png`). Default `rgb8`.
 
-## License
+Make sure to install the RealSense udev rules:
+<https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md>
 
-This project is licensed under Apache-2.0. Check out [NOTICE.md](../../NOTICE.md) for more information.
+## Usage
+
+```yaml
+nodes:
+  - id: dora-pyrealsense
+    hub: dora-pyrealsense@^0.5
+    inputs:
+      tick: dora/timer/millis/33
+    outputs:
+      - image
+      - depth
+```
+
+## Build
+
+```bash
+pip install .
+```

--- a/node-hub/dora-pyrealsense/dora-node.yml
+++ b/node-hub/dora-pyrealsense/dora-node.yml
@@ -1,0 +1,46 @@
+apiVersion: 1
+name: dora-pyrealsense
+namespace: dora-rs
+description: Captures aligned RGB color and depth frames from an Intel RealSense camera.
+categories: [sensor]
+keywords: [realsense, camera, depth, rgbd, intel]
+runtime: python
+entrypoint: dora-pyrealsense
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  tick:
+    required: true
+    description: Trigger to capture one aligned color + depth frame.
+outputs:
+  image:
+    description: Color frame as a flattened Arrow array; metadata carries width, height, encoding, resolution, focal_length, timestamp.
+  depth:
+    description: Aligned depth frame (mono16, values >5000 zeroed) as a flattened Arrow array, sharing the color frame metadata.
+env:
+  FLIP:
+    default: ""
+    description: Flip the color frame; one of VERTICAL, HORIZONTAL, BOTH (empty disables).
+  DEVICE_SERIAL:
+    default: ""
+    description: Serial number of the RealSense device to open (empty selects the default device).
+  IMAGE_HEIGHT:
+    type: int
+    default: 480
+    description: Requested stream height in pixels for both color and depth.
+  IMAGE_WIDTH:
+    type: int
+    default: 640
+    description: Requested stream width in pixels for both color and depth.
+  ENCODING:
+    default: rgb8
+    description: Color output encoding; rgb8, bgr8, or an OpenCV-encoded format (jpeg, jpg, jpe, bmp, webp, png).
+example: |
+  - id: dora-pyrealsense
+    hub: dora-pyrealsense@^0.5
+    inputs:
+      tick: dora/timer/millis/33
+    outputs:
+      - image
+      - depth

--- a/node-hub/dora-pyrealsense/dora_pyrealsense/main.py
+++ b/node-hub/dora-pyrealsense/dora_pyrealsense/main.py
@@ -26,7 +26,7 @@ def main():
 
     # Serial list
     serials = [device.get_info(rs.camera_info.serial_number) for device in devices]
-    if device_serial and (device_serial in serials):
+    if device_serial and (device_serial not in serials):
         raise ConnectionError(
             f"Device with serial {device_serial} not found within: {serials}.",
         )

--- a/node-hub/dora-pyrealsense/dora_pyrealsense/main.py
+++ b/node-hub/dora-pyrealsense/dora_pyrealsense/main.py
@@ -34,7 +34,10 @@ def main():
     pipeline = rs.pipeline()
 
     config = rs.config()
-    config.enable_device(device_serial)
+    # only request a specific device when a serial is given; an empty serial
+    # means "use the default device" (enable_device("") would request serial "")
+    if device_serial:
+        config.enable_device(device_serial)
     config.enable_stream(rs.stream.color, image_width, image_height, rs.format.rgb8, 30)
     config.enable_stream(rs.stream.depth, image_width, image_height, rs.format.z16, 30)
 

--- a/node-hub/dora-qwen/README.md
+++ b/node-hub/dora-qwen/README.md
@@ -1,37 +1,81 @@
 # dora-qwen
 
-## Getting started
+LLM text generation using Qwen2.5 — turns text prompts into generated text.
 
-- Install it with pip:
+## Behavior
 
-```bash
-pip install -e .
+`dora-qwen` connects as a dora node, loads a Qwen2.5-0.5B-Instruct model, and
+maintains a running conversation `history`. The backend is chosen by platform:
+
+- **Darwin (macOS):** GGUF model via `llama-cpp` (`Llama.from_pretrained`,
+  `create_chat_completion`).
+- **Linux:** Hugging Face `transformers` (`AutoModelForCausalLM` /
+  `AutoTokenizer`, `Qwen/Qwen2.5-0.5B-Instruct`).
+- **Other:** MLX (`mlx_lm`, `mlx-community/Qwen2.5-0.5B-Instruct-8bit`).
+
+For each input event:
+
+- An id containing `system_prompt` appends a system message and continues
+  (no generation).
+- An id containing `tools` parses the value as a JSON tool list and continues
+  (no generation).
+- Any other id is treated as prompt text. Each string is appended to the
+  history as a user turn, with optional inline role tags honored:
+  `<|system|>`, `<|assistant|>`, `<|tool|>`, `<|user|>\n<|im_start|>`, and
+  `<|user|>\n<|vision_start|>` (image url appended to the current user turn).
+
+After ingesting prompt text, the node generates a response and emits it on
+`text` — but only if `ACTIVATION_WORDS` is empty, or the prompt contains one of
+those words. Per-message tools can be supplied via the `tools` metadata key.
+
+## Inputs
+
+- `text` (required) — prompt text used to drive generation. Any input id other
+  than `system_prompt`/`tools` is treated as prompt text.
+- `system_prompt` (optional) — any id containing `system_prompt` sets the
+  system message; does not trigger generation.
+- `tools` (optional) — any id containing `tools` supplies a JSON tool list;
+  does not trigger generation.
+
+## Outputs
+
+- `text` — the generated assistant response, as a single-element UTF-8 string
+  Arrow array.
+
+## Environment variables
+
+- `SYSTEM_PROMPT` — system prompt initializing the conversation. Default:
+  `You're a very succinct AI assistant with short answers.`
+- `MODEL_NAME_OR_PATH` — GGUF repo id / path (Darwin backend). Default:
+  `Qwen/Qwen2.5-0.5B-Instruct-GGUF`.
+- `MODEL_FILE_PATTERN` — GGUF filename pattern (Darwin backend). Default:
+  `*fp16.gguf`.
+- `MAX_TOKENS` (int) — parsed at startup but not currently applied; generation
+  length is hardcoded per backend. Default: `512`.
+- `N_GPU_LAYERS` (int) — GPU layers for the llama-cpp (Darwin) backend.
+  Default: `0`.
+- `N_THREADS` (int) — CPU threads for the llama-cpp (Darwin) backend.
+  Default: `4`.
+- `CONTEXT_SIZE` (int) — context window (`n_ctx`) for the llama-cpp (Darwin)
+  backend. Default: `4096`.
+- `TOOLS_JSON` — JSON tool list applied at startup as the default tools.
+- `ACTIVATION_WORDS` — space-separated words; if set, generation only runs when
+  the prompt contains one of them. Empty means always generate.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-qwen
+    hub: dora-qwen@^0.5
+    inputs:
+      text: some-node/text
+    outputs:
+      - text
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-ruff check . --fix
+pip install .
 ```
-
-- Lint with ruff:
-
-```bash
-ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-qwen's code are released under the MIT License

--- a/node-hub/dora-qwen/README.md
+++ b/node-hub/dora-qwen/README.md
@@ -44,21 +44,16 @@ those words. Per-message tools can be supplied via the `tools` metadata key.
 
 ## Environment variables
 
-- `SYSTEM_PROMPT` — system prompt initializing the conversation. Default:
-  `You're a very succinct AI assistant with short answers.`
 - `MODEL_NAME_OR_PATH` — GGUF repo id / path (Darwin backend). Default:
   `Qwen/Qwen2.5-0.5B-Instruct-GGUF`.
 - `MODEL_FILE_PATTERN` — GGUF filename pattern (Darwin backend). Default:
   `*fp16.gguf`.
-- `MAX_TOKENS` (int) — parsed at startup but not currently applied; generation
-  length is hardcoded per backend. Default: `512`.
 - `N_GPU_LAYERS` (int) — GPU layers for the llama-cpp (Darwin) backend.
   Default: `0`.
 - `N_THREADS` (int) — CPU threads for the llama-cpp (Darwin) backend.
   Default: `4`.
 - `CONTEXT_SIZE` (int) — context window (`n_ctx`) for the llama-cpp (Darwin)
   backend. Default: `4096`.
-- `TOOLS_JSON` — JSON tool list applied at startup as the default tools.
 - `ACTIVATION_WORDS` — space-separated words; if set, generation only runs when
   the prompt contains one of them. Empty means always generate.
 

--- a/node-hub/dora-qwen/dora-node.yml
+++ b/node-hub/dora-qwen/dora-node.yml
@@ -33,19 +33,12 @@ outputs:
   text:
     description: Generated assistant response as a single-element UTF-8 string Arrow array.
 env:
-  SYSTEM_PROMPT:
-    default: "You're a very succinct AI assistant with short answers."
-    description: System prompt used to initialize the conversation.
   MODEL_NAME_OR_PATH:
     default: Qwen/Qwen2.5-0.5B-Instruct-GGUF
     description: Repo id / path of the GGUF model loaded via llama-cpp on Darwin.
   MODEL_FILE_PATTERN:
     default: "*fp16.gguf"
     description: GGUF filename pattern selected from the repo on Darwin.
-  MAX_TOKENS:
-    type: int
-    default: 512
-    description: Maximum generation tokens (parsed at startup; not currently applied — generation length is hardcoded per backend).
   N_GPU_LAYERS:
     type: int
     default: 0
@@ -58,9 +51,6 @@ env:
     type: int
     default: 4096
     description: Context window size (n_ctx) for the llama-cpp (Darwin) backend.
-  TOOLS_JSON:
-    default: ""
-    description: JSON tool list applied at startup as the default tools (overridable via the tools input or per-message metadata).
   ACTIVATION_WORDS:
     default: ""
     description: Space-separated words; if set, generation only runs when the prompt contains one of them. Empty means always generate.

--- a/node-hub/dora-qwen/dora-node.yml
+++ b/node-hub/dora-qwen/dora-node.yml
@@ -1,0 +1,73 @@
+apiVersion: 1
+name: dora-qwen
+namespace: dora-rs
+description: LLM text generation using Qwen2.5 — turns text prompts into generated text, with a system prompt, optional tools, and conversation history.
+categories: [llm]
+keywords: [llm, qwen, text-generation, chat]
+runtime: python
+entrypoint: dora-qwen
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  text:
+    required: true
+    description: >-
+      Prompt text appended to the conversation as a user turn and used to drive
+      generation. Any input id other than system_prompt/tools is treated as
+      prompt text. Optional inline role tags are honored: <|system|>,
+      <|assistant|>, <|tool|>, <|user|>\n<|im_start|>, and
+      <|user|>\n<|vision_start|> (image url).
+  system_prompt:
+    required: false
+    description: >-
+      Any input whose id contains "system_prompt" sets the system message for
+      the conversation (does not trigger generation).
+  tools:
+    required: false
+    description: >-
+      Any input whose id contains "tools" supplies a JSON tool list (parsed and
+      passed to generation on Darwin); does not trigger generation. Can also be
+      provided per-message via the "tools" metadata key.
+outputs:
+  text:
+    description: Generated assistant response as a single-element UTF-8 string Arrow array.
+env:
+  SYSTEM_PROMPT:
+    default: "You're a very succinct AI assistant with short answers."
+    description: System prompt used to initialize the conversation.
+  MODEL_NAME_OR_PATH:
+    default: Qwen/Qwen2.5-0.5B-Instruct-GGUF
+    description: Repo id / path of the GGUF model loaded via llama-cpp on Darwin.
+  MODEL_FILE_PATTERN:
+    default: "*fp16.gguf"
+    description: GGUF filename pattern selected from the repo on Darwin.
+  MAX_TOKENS:
+    type: int
+    default: 512
+    description: Maximum generation tokens (parsed at startup; not currently applied — generation length is hardcoded per backend).
+  N_GPU_LAYERS:
+    type: int
+    default: 0
+    description: Number of model layers offloaded to GPU for the llama-cpp (Darwin) backend.
+  N_THREADS:
+    type: int
+    default: 4
+    description: CPU thread count for the llama-cpp (Darwin) backend.
+  CONTEXT_SIZE:
+    type: int
+    default: 4096
+    description: Context window size (n_ctx) for the llama-cpp (Darwin) backend.
+  TOOLS_JSON:
+    default: ""
+    description: JSON tool list applied at startup as the default tools (overridable via the tools input or per-message metadata).
+  ACTIVATION_WORDS:
+    default: ""
+    description: Space-separated words; if set, generation only runs when the prompt contains one of them. Empty means always generate.
+example: |
+  - id: dora-qwen
+    hub: dora-qwen@^0.5
+    inputs:
+      text: some-node/text
+    outputs:
+      - text

--- a/node-hub/dora-qwen/dora_qwen/main.py
+++ b/node-hub/dora-qwen/dora_qwen/main.py
@@ -201,7 +201,7 @@ def main():
                     response = model.create_chat_completion(
                         messages=history,  # Prompt
                         max_tokens=150,
-                        tools=tools,
+                        tools=tmp_tools,
                     )["choices"][0]["message"]["content"]
 
                     history += [{"role": "assistant", "content": response}]

--- a/node-hub/terminal-input/README.md
+++ b/node-hub/terminal-input/README.md
@@ -15,6 +15,8 @@ isn't connected yet it waits and retries, so wiring order doesn't matter.
   `Received: <value>`.
 - **Single-shot mode** (`DATA` env var set, or `DORA_NODE_CONFIG` present): it
   parses the value once, wraps it in a `pyarrow` array, and sends it as `data`.
+  Under Hub (`DORA_NODE_CONFIG` is set), the node is non-interactive, so `DATA`
+  **must** be provided — otherwise there is nothing to send and it errors.
 
 ## Inputs
 
@@ -29,8 +31,9 @@ wired to it and prints them, but there is no fixed or typed input contract (so
 
 ## Environment variables
 
-- `DATA` — if set, sends this value once instead of prompting interactively on
-  stdin.
+- `DATA` — the value to send (parsed via `ast.literal_eval`). **Required under
+  Hub** (a daemon-spawned node is non-interactive). Only when run standalone on a
+  terminal does the node prompt for input instead.
 
 ## Usage
 
@@ -38,6 +41,8 @@ wired to it and prints them, but there is no fixed or typed input contract (so
 nodes:
   - id: terminal-input
     hub: terminal-input@^0.5
+    env:
+      DATA: "Hello, dora!"
     outputs:
       - data
 ```

--- a/node-hub/terminal-input/README.md
+++ b/node-hub/terminal-input/README.md
@@ -1,5 +1,49 @@
-# Dora Node for sending terminal input data.
+# terminal-input
 
-This node send the data that is given to him within a terminal window.
+Reads data from the terminal (or the `DATA` env var) and emits it as an Apache Arrow output.
 
-Check example at [examples/echo](examples/echo)
+## Behavior
+
+`terminal-input` connects as a dora node and sends a `data` output. If the node
+isn't connected yet it waits and retries, so wiring order doesn't matter.
+
+- **Interactive mode** (no `DATA` env var and no `DORA_NODE_CONFIG`): it prompts
+  `Provide the data you want to send:` on stdin in a loop. Each line is parsed
+  with `ast.literal_eval` (falling back to a plain string on `ValueError` /
+  `SyntaxError`), wrapped in a `pyarrow` array, and sent as the `data` output.
+  After each send it drains any pending input events and prints them as
+  `Received: <value>`.
+- **Single-shot mode** (`DATA` env var set, or `DORA_NODE_CONFIG` present): it
+  parses the value once, wraps it in a `pyarrow` array, and sends it as `data`.
+
+## Inputs
+
+None declared. In interactive mode it does read back any input events that are
+wired to it and prints them, but there is no fixed or typed input contract (so
+`dora-node.yml` declares none).
+
+## Outputs
+
+- `data` — the value typed at the prompt (or taken from the `DATA` env var),
+  parsed via `ast.literal_eval` and wrapped in an Arrow array.
+
+## Environment variables
+
+- `DATA` — if set, sends this value once instead of prompting interactively on
+  stdin.
+
+## Usage
+
+```yaml
+nodes:
+  - id: terminal-input
+    hub: terminal-input@^0.5
+    outputs:
+      - data
+```
+
+## Build
+
+```bash
+pip install .
+```

--- a/node-hub/terminal-input/dora-node.yml
+++ b/node-hub/terminal-input/dora-node.yml
@@ -14,9 +14,11 @@ outputs:
     description: The value typed at the prompt (or taken from the DATA env var), parsed via ast.literal_eval and wrapped in an Arrow array.
 env:
   DATA:
-    description: If set, sends this value once instead of prompting interactively on stdin.
+    description: The value to send (parsed via ast.literal_eval). Required under Hub — a daemon-spawned node is non-interactive, so without DATA there is nothing to prompt for and the node errors. (Only when run standalone on a terminal does it prompt for input instead.)
 example: |
   - id: terminal-input
     hub: terminal-input@^0.5
+    env:
+      DATA: "Hello, dora!"
     outputs:
       - data

--- a/node-hub/terminal-input/dora-node.yml
+++ b/node-hub/terminal-input/dora-node.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+name: terminal-input
+namespace: dora-rs
+description: Reads data from the terminal (or the DATA env var) and emits it as an Arrow output.
+categories: [debug]
+keywords: [terminal, input, stdin, sender, debug]
+runtime: python
+entrypoint: terminal-input
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+outputs:
+  data:
+    description: The value typed at the prompt (or taken from the DATA env var), parsed via ast.literal_eval and wrapped in an Arrow array.
+env:
+  DATA:
+    description: If set, sends this value once instead of prompting interactively on stdin.
+example: |
+  - id: terminal-input
+    hub: terminal-input@^0.5
+    outputs:
+      - data

--- a/node-hub/video-encoder/README.md
+++ b/node-hub/video-encoder/README.md
@@ -1,28 +1,73 @@
-## Camera Node for OpenCV compatible cameras
+# video-encoder
 
-Simple Camera node that uses OpenCV to capture images from a camera. The node can be configured to use a specific camera
-id, width and height.
-It then sends the images to the dataflow.
+Records incoming image frames per episode and encodes them into an H.264 MP4
+video (LeRobot compatible).
 
-## YAML Configuration
+## Behavior
 
-````YAML
+`video-encoder` connects as a dora node (its node name defaults to
+`video_encoder`, overridable with `--name`). On startup it requires the
+`VIDEO_NAME` and `FPS` environment variables and raises a `ValueError` if either
+is unset.
+
+It tracks two pieces of state: whether it is currently recording and the current
+episode index. Recording is toggled by the `episode_index` input:
+
+- An `episode_index` value other than `-1` selects that episode and starts
+  recording.
+- An `episode_index` of `-1` stops recording and encodes the buffered frames.
+
+While recording, each `image` input frame is reshaped to
+`(height, width, channels)` and written to disk as a PNG under
+`out/<dataflow_id>/videos/<VIDEO_NAME>_episode_<index>/frame_<n>.png`, and an
+`image` output referencing the target video is emitted.
+
+When recording stops (`episode_index == -1`), the buffered PNG frames are encoded
+with ffmpeg (`libx264`, `pix_fmt yuv444p`, GOP size 2, rate `FPS`) into
+`out/<dataflow_id>/videos/<VIDEO_NAME>_episode_<index>.mp4`, and the frame
+counter resets.
+
+An initial `image` output is also sent once at startup before any input arrives.
+
+## Inputs
+
+- `image` — an image frame as an Arrow struct with `width`, `height`,
+  `channels`, and `data`. Buffered to disk as a PNG only while recording.
+- `episode_index` — episode index integer. A value other than `-1` starts
+  recording that episode; `-1` ends the episode and triggers MP4 encoding.
+
+## Outputs
+
+- `image` — a reference to the encoded video file as an Arrow struct
+  `{path, timestamp}` (path relative to the videos directory; timestamp =
+  `frame_count / FPS`). Emitted once at startup and once per recorded frame.
+
+## Environment variables
+
+- `VIDEO_NAME` (required) — base name for the per-episode output directory and
+  the resulting `.mp4` file.
+- `FPS` (required, integer) — frames per second; used to compute frame
+  timestamps and as the ffmpeg input/encode rate.
+
+## Usage
+
+```yaml
 nodes:
-  - id: video_encoder
-    path: encoder.py # modify this to the relative path from the graph file to the client script
+  - id: video-encoder
+    hub: video-encoder@^0.5
     inputs:
-    # image: some image from other node
-    # episode_index: some episode index from other node
+      image: camera/image
+      episode_index: recorder/episode_index
     outputs:
       - image
 
     env:
       VIDEO_NAME: cam_up
-      VIDEO_WIDTH: 640
-      VIDEO_HEIGHT: 480
       FPS: 30
-````
+```
 
-## License
+## Build
 
-This library is licensed under the [Apache License 2.0](../../LICENSE).
+```bash
+pip install .
+```

--- a/node-hub/video-encoder/dora-node.yml
+++ b/node-hub/video-encoder/dora-node.yml
@@ -1,0 +1,37 @@
+apiVersion: 1
+name: video-encoder
+namespace: dora-rs
+description: Records incoming image frames per episode and encodes them into an H.264 MP4 video (LeRobot compatible).
+categories: [transform]
+keywords: [video, encode, codec, h264, ffmpeg, lerobot]
+runtime: python
+entrypoint: video-encoder
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  image:
+    required: true
+    description: Image frame (Arrow struct with width, height, channels, data); buffered to disk as PNG while an episode is recording.
+  episode_index:
+    required: true
+    description: Episode index; a value other than -1 starts recording that episode, -1 ends it and encodes the buffered frames into an MP4.
+outputs:
+  image:
+    description: Reference to the encoded video file as an Arrow struct {path, timestamp}; emitted once at startup and per recorded frame.
+env:
+  VIDEO_NAME:
+    default: cam_up
+    description: Required. Base name used for the per-episode output directory and the resulting .mp4 file.
+  FPS:
+    type: int
+    default: 30
+    description: Required. Frames per second used to compute frame timestamps and as the ffmpeg input/encode rate.
+example: |
+  - id: video-encoder
+    hub: video-encoder@^0.5
+    inputs:
+      image: camera/image
+      episode_index: recorder/episode_index
+    outputs:
+      - image

--- a/node-hub/video-encoder/dora-node.yml
+++ b/node-hub/video-encoder/dora-node.yml
@@ -21,17 +21,18 @@ outputs:
     description: Reference to the encoded video file as an Arrow struct {path, timestamp}; emitted once at startup and per recorded frame.
 env:
   VIDEO_NAME:
-    default: cam_up
-    description: Required. Base name used for the per-episode output directory and the resulting .mp4 file.
+    description: Base name used for the per-episode output directory and the resulting .mp4 file. Required — the node raises at startup if unset (no default).
   FPS:
     type: int
-    default: 30
-    description: Required. Frames per second used to compute frame timestamps and as the ffmpeg input/encode rate.
+    description: Frames per second used to compute frame timestamps and as the ffmpeg input/encode rate. Required — the node raises at startup if unset (no default).
 example: |
   - id: video-encoder
     hub: video-encoder@^0.5
     inputs:
       image: camera/image
       episode_index: recorder/episode_index
+    env:
+      VIDEO_NAME: cam_up
+      FPS: 30
     outputs:
       - image


### PR DESCRIPTION
Source-side Hub migration, batch 2 (after #76 template, #77 batch 1). Adds a `dora-node.yml` typed contract + normalized README for 10 more nodes; every manifest is derived from the node's actual `main.py` and passes `dora validate --node-manifest`.

| Node | Category | Contract |
|------|----------|----------|
| `dora-keyboard` | sensor | keyboard → `char` |
| `terminal-input` | — | stdin → `data` |
| `dora-distil-whisper` | speech, ml-inference | audio → `text` + `speech_started` |
| `dora-kokoro-tts` | speech | `text` → `audio` |
| `dora-qwen` | llm | `text` → `text` |
| `dora-mediapipe` | ml-inference | `image`(+`depth`) → `points2d`/`points3d` |
| `dora-pyrealsense` | sensor | `tick` → `image`/`depth` |
| `video-encoder` | transform | `image`/`episode_index` → `image` |
| `dora-pyaudio` | actuator, speech | `audio` playback sink (no outputs) |
| `dora-piper` | robot | `joint_action`/`eef_action` → `jointstate`/`pose`/`gripper` |

Ports declared **untyped** this pass (type URNs are a later typed pass).

**Drift fixed while reading code:**
- `dora-pyrealsense` README was copied from opencv-video-capture (wrong node id/path, a `PATH` env the code never reads) and omitted the `depth` output.
- `video-encoder` README was copied from opencv and declared `VIDEO_WIDTH`/`VIDEO_HEIGHT` env vars the code never reads.
- `dora-distil-whisper` README missed the `speech_started` output and several env vars.
- `dora-keyboard`/`dora-kokoro-tts`/`dora-pyaudio`/`dora-mediapipe` had placeholder pyproject descriptions.

16 of 62 nodes now migrated (#76 + #77's 5 + these 10). Source-side only; publish entries follow once these land + OWNERS is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)