### PR TITLE
feat(node-hub): Hub migration batch 5 — 13 nodes

### DIFF
--- a/node-hub/dora-cotracker/README.md
+++ b/node-hub/dora-cotracker/README.md
@@ -1,45 +1,55 @@
 # dora-cotracker
 
-A Dora node that implements real-time object tracking using Facebook's CoTracker model. The node supports both interactive point selection via clicking and programmatic point input through Dora's messaging system.
+Real-time point tracking using Facebook's CoTracker model. Consumes an RGB image
+stream plus query points (raw points or 2D bounding boxes) and emits the tracked
+point positions and an annotated visualization frame.
 
-## Features
+## Behavior
 
-- Real-time object tracking using CoTracker
-- Support for multiple tracking points
-- Interactive point selection via mouse clicks
-- Programmatic point input through Dora messages
-- Visualization of tracked points with unique identifiers
+On startup the node loads the `cotracker3_online` model via `torch.hub` (using
+CUDA if available, otherwise CPU) and runs an online tracker over a sliding
+window of frames.
 
-## Getting Started
+- Each `image` frame is appended to the tracking window and reshaped to
+  `(height, width, 3)` from its `width`/`height` metadata.
+- Once the window is full, the model tracks the current query points and emits
+  the visible points (visibility > 0.5) on `points`, plus an annotated frame on
+  `tracked_image`.
+- Query points come from `points` (a flattened x,y array) or `boxes2d` (bounding
+  boxes, from which sample points are derived). New query points are accepted
+  only after the previous batch has been consumed; an empty `boxes2d` clears the
+  current points.
+- When `INTERACTIVE_MODE` is true, an OpenCV window is shown and left-clicking
+  adds tracking points interactively.
 
-### Installation
+## Inputs
 
-Install using uv:
+- `image` (required): RGB video frame as a flattened uint8 Arrow array; metadata
+  must include `width` and `height`.
+- `points`: query points to track, a flattened float array of x,y coordinates
+  (reshaped to `(-1, 2)`).
+- `boxes2d`: 2D bounding boxes (a `StructArray` with `bbox`/`labels`, or a flat
+  array reshaped to `(-1, 4)`); sample points are derived from each box. An empty
+  value clears the current query points.
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
-```
+## Outputs
 
-## Demo Video
+- `points`: visible tracked point positions as a flattened float32 Arrow array.
+  Metadata: `num_points`, `dtype`, `shape` `(N, 2)`, `width`, `height`.
+- `tracked_image`: the input frame annotated with tracked points, carrying the
+  input image metadata.
 
-Watch a demonstration of the dora-cotracker node in action:
+## Environment variables
 
-[![Dora CoTracker Demo](https://img.youtube.com/vi/1VmC1BNq6J0/0.jpg)](https://youtu.be/1VmC1BNq6J0)
+- `INTERACTIVE_MODE` (bool, default `false`): when true, opens an OpenCV window
+  showing the feed and lets you left-click to add tracking points. Requires a
+  display; leave false for headless runs.
 
-The video shows:
-- Setting up the node
-- Interactive point selection
-- Real-time tracking performance
-
-### Basic Usage
-
-1. Create a YAML configuration file (e.g., `demo.yml`):
+## Usage
 
 ```yaml
 nodes:
   - id: camera
-    build: pip install opencv-video-capture
     path: opencv-video-capture
     inputs:
       tick: dora/timer/millis/100
@@ -50,172 +60,17 @@ nodes:
       ENCODING: "rgb8"
       IMAGE_WIDTH: "640"
       IMAGE_HEIGHT: "480"
-
   - id: tracker
-    build: pip install -e dora-cotracker
-    path: dora-cotracker
+    hub: dora-cotracker@^0.5
     inputs:
       image: camera/image
-      points_to_track: input/points_to_track
     outputs:
+      - points
       - tracked_image
-      - tracked_points
-
-  - id: display
-    build: pip install dora-rerun
-    path: dora-rerun
-    inputs:
-      image: camera/image
-      tracked_image: tracker/tracked_image
 ```
 
-*Note* - this only has the cv2 as an input source. see below to add your nodes workflow and pass points directly.
-
-2. Run the demo:
+## Build
 
 ```bash
-dora run demo.yml --uv
+pip install .
 ```
-
-## Usage Examples
-
-### 1. Interactive Point Selection
-Click points directly in the "Raw Feed" window to start tracking them:
-- Left-click to add tracking points
-- Points will be tracked automatically across frames
-- Each point is assigned a unique identifier (C0, C1, etc. for clicked points and I0, I1, etc for input points)
-
-### 2. Dynamic Point Integration
-The node can receive tracking points from other models or nodes in your pipeline. Common use cases include:
-
-- Tracking YOLO detection centroids
-- Following pose estimation keypoints
-- Monitoring segmentation mask centers
-- Custom object detection points
-
-example showing how to send tracking points through Dora messages using a custom input node:
-
-```python
-import numpy as np
-import pyarrow as pa
-from dora import Node
-
-class PointInputNode:
-    def __init__(self):
-        self.node = Node("point-input")
-    
-    def send_points(self, points):
-        """
-        Send points to tracker
-        Args:
-            points: Nx2 array of (x,y) coordinates
-        """
-        points = np.array(points, dtype=np.float32)
-        self.node.send_output(
-            "points_to_track",
-            pa.array(points.ravel()),
-            {
-                "num_points": len(points),
-                "dtype": "float32", 
-                "shape": (len(points), 2)
-            }
-        )
-
-    def run(self):
-        # Example: Track 3 points
-        points = np.array([
-            [320, 240],  # Center
-            [160, 120],  # Top-left
-            [480, 360]   # Bottom-right
-        ])
-        self.send_points(points)
-```
-
-
-
-To connect your existing node that outputs tracking points with the CoTracker node, add the following to your YAML configuration:
-
-```yaml
-nodes:
-  # Your existing point source node (e.g., YOLO detector, pose estimator, etc.)
-  - id: point_source
-    build: pip install your-node  # Replace with your node's name
-    path: your-point-source-node  # Replace with your node's path
-    inputs:
-      image: camera/image  # If your node needs image input
-    outputs:
-      - points_to_track    # Must output points in required format
-
-  # CoTracker node configuration
-  - id: tracker
-    build: pip install dora-cotracker
-    path: dora-cotracker
-    inputs:
-      image: camera/image
-      points_to_track: point_source/points_to_track  # Connect to your point source
-    outputs:
-      - tracked_image
-      - tracked_points
-
-  # Optional visualization
-  - id: display
-    build: pip install dora-rerun
-    path: dora-rerun
-    inputs:
-      image: camera/image
-      tracked_image: tracker/tracked_image
-```
-
-Your point source node must output points in the following format:
-- Topic name: `points_to_track`
-- Data: Flattened numpy array of x,y coordinates
-- Metadata:
-  ```python
-  {
-      "num_points": len(points),  # Number of points
-      "dtype": "float32",        # Data type
-      "shape": (N, 2)           # N points, 2 coordinates each
-  }
-  ```
-
-Example point source implementations:
-- YOLO detection centroids
-- Pose estimation keypoints
-- Face landmark detectors
-- Custom object detectors
-
-For dynamic updates, send new points whenever your source node processes a new frame. The tracker will maintain temporal consistency between updates.
-**
-## API Reference
-
-### Input Topics
-- `image`: Input video stream (RGB format)
-- `points_to_track`: Points to track
-  - Format: Flattened array of x,y coordinates
-  - Metadata: 
-    - `num_points`: Number of points
-    - `dtype`: "float32"
-    - `shape`: (N, 2) where N is number of points
-
-### Output Topics
-- `tracked_image`: Visualization with tracked points
-- `tracked_points`: Current positions of tracked points
-  - Same format as input points
-
-## Development
-
-Format code with ruff:
-```bash
-uv pip install ruff
-uv run ruff check . --fix
-```
-
-Run tests:
-```bash
-uv pip install pytest
-uv run pytest
-```
-
-## License
-
-dora-cotracker's code are released under the MIT License

--- a/node-hub/dora-cotracker/dora-node.yml
+++ b/node-hub/dora-cotracker/dora-node.yml
@@ -1,0 +1,77 @@
+apiVersion: 1
+name: dora-cotracker
+namespace: dora-rs
+description: >-
+  Real-time point tracking using Facebook's CoTracker model. Consumes an RGB
+  image stream plus query points (raw points or 2D bounding boxes) and emits the
+  tracked point positions and an annotated visualization frame.
+categories:
+  - ml-inference
+  - transform
+keywords:
+  - tracking
+  - cotracker
+  - points
+  - vision
+runtime: python
+entrypoint: dora-cotracker
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    description: >-
+      RGB video frame as a flattened uint8 Arrow array. Metadata must include
+      `width` and `height`; reshaped to (height, width, 3).
+    required: true
+  points:
+    description: >-
+      Query points to track, as a flattened float array of x,y coordinates
+      (reshaped to (-1, 2)). New points are accepted only after the previous
+      batch has been consumed by the tracker.
+    required: false
+  boxes2d:
+    description: >-
+      2D bounding boxes (StructArray with `bbox`/`labels`, or a flat array
+      reshaped to (-1, 4)). Sample points are derived along each box and used as
+      query points. An empty value clears the current query points.
+    required: false
+
+outputs:
+  points:
+    description: >-
+      Visible tracked point positions as a flattened float32 Arrow array.
+      Metadata: `num_points`, `dtype`, `shape` (N, 2), `width`, `height`.
+  tracked_image:
+    description: >-
+      The input frame annotated with tracked points, as a flattened Arrow array
+      carrying the input image metadata.
+
+env:
+  INTERACTIVE_MODE:
+    type: bool
+    default: false
+    description: >-
+      When true, opens an OpenCV window showing the feed and lets you left-click
+      to add tracking points. Requires a display; leave false for headless runs.
+
+example: |
+  - id: camera
+    path: opencv-video-capture
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - image
+    env:
+      CAPTURE_PATH: "0"
+      ENCODING: "rgb8"
+      IMAGE_WIDTH: "640"
+      IMAGE_HEIGHT: "480"
+  - id: tracker
+    hub: dora-cotracker@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - points
+      - tracked_image

--- a/node-hub/dora-cotracker/dora_cotracker/main.py
+++ b/node-hub/dora-cotracker/dora_cotracker/main.py
@@ -12,7 +12,7 @@ INTERACTIVE_MODE = os.getenv("INTERACTIVE_MODE", "false").lower() == "true"
 
 class VideoTrackingNode:
     def __init__(self):
-        self.node = Node("video-tracking-node")
+        self.node = Node()
         # Initialize CoTracker
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model = torch.hub.load("facebookresearch/co-tracker", "cotracker3_online")

--- a/node-hub/dora-dataset-record/README.md
+++ b/node-hub/dora-dataset-record/README.md
@@ -1,108 +1,110 @@
 # dora-dataset-record
 
-Node for recording robot datasets in LeRobot format. You can captures synchronized camera feeds and robot poses to create high-quality datasets for imitation learning and robot training.
+Record synchronized camera feeds and robot state/action streams into a
+HuggingFace [LeRobot](https://github.com/huggingface/lerobot) dataset, for
+imitation learning and robot training.
 
-- **Robot pose recording** - Capture both state and action data
-- **Multi-camera support** - Record from multiple cameras simultaneously
-- **LeRobot dataset format (v2.1)** - Direct integration with HuggingFace LeRobot datasets
-- **Episode management** - Automatic episode segmentation with reset phases
+## Behavior
 
-## Quick Start
+The node connects as a dora node and a background timer adds one frame to the
+dataset every `1/FPS` seconds while an episode is active. Each frame is built
+from the latest values it has received per input:
 
-### 1. Installation
+- `robot_action` is stored as the `action` feature.
+- `robot_state` is stored as the `observation.state` feature.
+- Any input whose metadata carries `height` and `width` is treated as a camera
+  frame and stored as `observation.images.<input-id>` (the input id must be one
+  of `CAMERA_NAMES`). `bgr8` and `yuv420` encodings are converted to RGB.
+- When `SAVE_AVIF_FRAMES=true`, inputs named `rav1e_<camera>` are written
+  verbatim as `.avif` files alongside the dataset.
 
-```bash
-# Source your venv
-cd dora/node-hub/dora-dataset-record
-uv pip install -e .
-```
+A frame is only added once every feature declared by `ROBOT_JOINTS` and
+`CAMERA_NAMES` is present. Recording runs for `TOTAL_EPISODES` episodes of
+`EPISODE_DURATION_S` each, separated by `RESET_DURATION_S` reset phases (input
+during a reset phase is dropped), then the node finalizes the dataset
+(optionally pushing it to the Hub) and stops. Status messages are emitted on the
+`text` output.
 
-### 2. Usage Guide
+## Inputs
 
-Create a dataflow file, see `examples/lerobot-dataset-record/dataset_record.yml`:
+- `robot_state`: robot observation pose, a float array with one value per
+  `ROBOT_JOINTS` entry (radians). Stored as `observation.state`.
+- `robot_action`: robot action pose, a float array with one value per
+  `ROBOT_JOINTS` entry (radians). Stored as `action`.
+- `<camera-name>`: a camera frame carrying `height`/`width` metadata, stored as
+  `observation.images.<camera-name>`. Wire one input per entry in
+  `CAMERA_NAMES` (e.g. `laptop`, `front`).
+- `rav1e_<camera-name>`: optional AVIF-encoded frame for a camera, used only
+  when `SAVE_AVIF_FRAMES=true`.
+
+A `hub:` contract must declare every wired input, so the contract declares
+`robot_state`, `robot_action`, and example `laptop` / `rav1e_laptop` camera
+inputs. Camera input ids are dynamic (driven by `CAMERA_NAMES`); rename or add
+camera inputs to match your cameras.
+
+## Outputs
+
+- `text`: status messages about the recording lifecycle (episode start, reset
+  phase, episode saved, completion).
+
+## Environment variables
+
+Required:
+
+- `REPO_ID`: HuggingFace dataset repo id (e.g. `username/dataset_name`).
+- `ROBOT_JOINTS`: comma-separated joint names defining the `action` /
+  `observation.state` shape.
+
+Optional:
+
+- `SINGLE_TASK` (default `Your task`): task description attached to each frame.
+- `CAMERA_NAMES` (default unset): comma-separated camera names. Each name needs
+  a matching input and a `CAMERA_<NAME>_RESOLUTION` variable. No cameras are
+  recorded if unset.
+- `CAMERA_<NAME>_RESOLUTION`: per-camera resolution as `height,width,channels`
+  (e.g. `CAMERA_LAPTOP_RESOLUTION: 480,640,3`). One per camera name; not set if
+  the camera is omitted.
+- `FPS` (default `30`): recording frame rate.
+- `TOTAL_EPISODES` (default `10`): number of episodes to record.
+- `EPISODE_DURATION_S` (default `60`): episode length in seconds.
+- `RESET_DURATION_S` (default `15`): reset break between episodes in seconds.
+- `USE_VIDEOS` (default `true`): encode frames as MP4 video, else store images.
+- `SAVE_AVIF_FRAMES` (default `false`): also save AVIF frames from
+  `rav1e_<camera>` inputs.
+- `ROBOT_TYPE` (default `your_robot_type`): robot type in dataset metadata.
+- `ROOT_PATH` (default unset): local dataset directory; LeRobot cache if unset.
+- `IMAGE_WRITER_PROCESSES` (default `0`): LeRobot image-writer subprocesses.
+- `IMAGE_WRITER_THREADS` (default `4`): LeRobot image-writer threads per camera.
+- `PUSH_TO_HUB` (default `false`): upload the dataset when finished.
+- `PRIVATE` (default `false`): make the pushed dataset private.
+- `TAGS` (default unset): comma-separated tags attached when pushing to Hub.
+
+## Usage
 
 ```yaml
 nodes:
-  # Dataset recorder
-  - id: dataset_recorder
-    build: pip install -e ../../dora-dataset-record
-    path: dora-dataset-record
+  - id: dataset-record
+    hub: dora-dataset-record@^0.5
     inputs:
-      laptop: laptop_cam/image
-      front: front_cam/image
-      robot_state: robot_follower/pose
-      robot_action: leader_interface/pose
+      laptop: laptop-cam/image
+      front: front-cam/image
+      robot_state: robot-follower/pose
+      robot_action: leader-interface/pose
     outputs:
       - text
     env:
-      # Required settings
-      REPO_ID: "your_username/your_dataset_name"
-      SINGLE_TASK: "Pick up the cube and place it in the box"
-      ROBOT_TYPE: "your_robot_type"
-
-      # Recording settings
-      FPS: "30"
-      TOTAL_EPISODES: "50"
-      EPISODE_DURATION_S: "60"
-      RESET_DURATION_S: "15"
-
-      # Camera configuration
-      CAMERA_NAMES: "laptop,front"
-      CAMERA_LAPTOP_RESOLUTION: "480,640,3"
-      CAMERA_FRONT_RESOLUTION: "480,640,3"
-
-      # Robot configuration
-      ROBOT_JOINTS: "joint1,joint2,joint3,joint4,joint5,gripper"
-
-      # Optional settings
-      USE_VIDEOS: "true"
-      SAVE_AVIF_FRAMES: "true" # This will additionally save frames
-      PUSH_TO_HUB: "false"
-      PRIVATE: "false"
-      TAGS: "robotics,manipulation,imitation_learning"
-
-  # Visualization with rerun
-  - id: plot
-    build: pip install dora-rerun
-    path: dora-rerun
-    inputs:
-      text: dataset_recorder/text
+      REPO_ID: your_username/your_dataset_name
+      SINGLE_TASK: Pick up the cube and place it in the box
+      ROBOT_JOINTS: joint1,joint2,joint3,joint4,joint5,gripper
+      CAMERA_NAMES: laptop,front
+      CAMERA_LAPTOP_RESOLUTION: 480,640,3
+      CAMERA_FRONT_RESOLUTION: 480,640,3
+      FPS: 30
+      TOTAL_EPISODES: 50
 ```
 
-### 3. Start Recording the dataset
+## Build
 
 ```bash
-dora build dataset_record.yml
-dora run dataset_record.yml
+pip install .
 ```
-
-The node will send instructions on dora-rerun, about episode starting, reset time, Saving episodes etc.
-
-## Configuration
-
-### Required Environment Variables
-
-| Variable              | Description                  | Example                    |
-| --------------------- | ---------------------------- | -------------------------- |
-| `REPO_ID`             | HuggingFace dataset repo     | `"username/dataset_name"`  |
-| `SINGLE_TASK`         | Task description             | `"Pick and place objects"` |
-| `CAMERA_NAMES`        | Comma-separated camera names | `"laptop,front,top"`       |
-| `CAMERA_*_RESOLUTION` | Resolution for each camera   | `"480,640,3"`              |
-| `ROBOT_JOINTS`        | Comma-separated joint names  | `"joint1,joint2,gripper"`  |
-
-### Optional Settings
-
-| Variable             | Default                                     | Description                                           |
-| -------------------- | ------------------------------------------- | ----------------------------------------------------- |
-| `FPS`                | `30`                                        | Recording frame rate (match camera fps)               |
-| `TOTAL_EPISODES`     | `10`                                        | Number of episodes to record                          |
-| `EPISODE_DURATION_S` | `60`                                        | Episode length in seconds                             |
-| `RESET_DURATION_S`   | `15`                                        | Break between episodes to reset the environment       |
-| `USE_VIDEOS`         | `true`                                      | Encode as MP4 videos, else saves images               |
-| `PUSH_TO_HUB`        | `false`                                     | Upload to HuggingFace Hub                             |
-| `PRIVATE`            | `false`                                     | Make dataset private                                  |
-| `ROOT_PATH`          | `~/.cache/huggingface/lerobot/your_repo_id` | Local storage path where you want to save the dataset |
-
-## License
-
-This project is released under the MIT License.

--- a/node-hub/dora-dataset-record/dora-node.yml
+++ b/node-hub/dora-dataset-record/dora-node.yml
@@ -27,14 +27,15 @@ inputs:
   laptop:
     description: >-
       Camera frame stored as observation.images.<camera-name>. The input id must
-      match a name in CAMERA_NAMES, and the frame must carry height/width
-      metadata. Declare one input per camera in CAMERA_NAMES (laptop and front
-      are the defaults); the hub contract rejects camera ids not declared here.
+      match a name in CAMERA_NAMES (which has no default and must be set), and the
+      frame must carry height/width metadata. Declare one input per camera you
+      list (laptop and front are used in the example below); the hub contract
+      rejects camera ids not declared here.
     required: false
   front:
     description: >-
       Second camera frame stored as observation.images.front. Same contract as
-      laptop; declared because the default CAMERA_NAMES is `laptop,front`.
+      laptop; declared because the example sets `CAMERA_NAMES: laptop,front`.
     required: false
   rav1e_laptop:
     description: >-

--- a/node-hub/dora-dataset-record/dora-node.yml
+++ b/node-hub/dora-dataset-record/dora-node.yml
@@ -28,8 +28,13 @@ inputs:
     description: >-
       Camera frame stored as observation.images.<camera-name>. The input id must
       match a name in CAMERA_NAMES, and the frame must carry height/width
-      metadata. Add one input per camera (e.g. laptop, front); this entry is an
-      example named after CAMERA_NAMES.
+      metadata. Declare one input per camera in CAMERA_NAMES (laptop and front
+      are the defaults); the hub contract rejects camera ids not declared here.
+    required: false
+  front:
+    description: >-
+      Second camera frame stored as observation.images.front. Same contract as
+      laptop; declared because the default CAMERA_NAMES is `laptop,front`.
     required: false
   rav1e_laptop:
     description: >-

--- a/node-hub/dora-dataset-record/dora-node.yml
+++ b/node-hub/dora-dataset-record/dora-node.yml
@@ -94,7 +94,6 @@ env:
     description: Robot type recorded in the dataset metadata.
   ROOT_PATH:
     type: string
-    default: ""
     description: >-
       Local directory to store the dataset. Defaults to the LeRobot cache
       location when empty.

--- a/node-hub/dora-dataset-record/dora-node.yml
+++ b/node-hub/dora-dataset-record/dora-node.yml
@@ -1,0 +1,140 @@
+apiVersion: 1
+name: dora-dataset-record
+namespace: dora-rs
+description: >-
+  Record synchronized camera feeds and robot state/action streams into a
+  HuggingFace LeRobot dataset, with automatic episode segmentation and reset
+  phases.
+categories: [recorder, robot]
+keywords: [lerobot, dataset, recording, imitation-learning, camera, robot]
+runtime: python
+entrypoint: dora-dataset-record
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  robot_state:
+    description: >-
+      Robot observation pose as a float array of joint values (radians, one per
+      ROBOT_JOINTS entry). Stored as observation.state.
+    required: false
+  robot_action:
+    description: >-
+      Robot action pose as a float array of joint values (radians, one per
+      ROBOT_JOINTS entry). Stored as action.
+    required: false
+  laptop:
+    description: >-
+      Camera frame stored as observation.images.<camera-name>. The input id must
+      match a name in CAMERA_NAMES, and the frame must carry height/width
+      metadata. Add one input per camera (e.g. laptop, front); this entry is an
+      example named after CAMERA_NAMES.
+    required: false
+  rav1e_laptop:
+    description: >-
+      Optional AVIF-encoded frame for a camera, written verbatim to disk when
+      SAVE_AVIF_FRAMES=true. The id is rav1e_<camera-name>. Add one per camera.
+    required: false
+
+outputs:
+  text:
+    description: >-
+      Status messages about recording lifecycle (episode start, reset phase,
+      episode saved, completion).
+
+env:
+  REPO_ID:
+    type: string
+    description: >-
+      HuggingFace dataset repo id (e.g. username/dataset_name). Required.
+  SINGLE_TASK:
+    type: string
+    default: Your task
+    description: Task description attached to every recorded frame.
+  ROBOT_JOINTS:
+    type: string
+    description: >-
+      Comma-separated robot joint names defining the action / observation.state
+      feature shape. Required.
+  CAMERA_NAMES:
+    type: string
+    description: >-
+      Comma-separated camera names. Each name must have a matching input id and
+      a CAMERA_<NAME>_RESOLUTION variable. If unset, no cameras are recorded.
+    default: ""
+  FPS:
+    type: int
+    default: 30
+    description: Recording frame rate.
+  TOTAL_EPISODES:
+    type: int
+    default: 10
+    description: Number of episodes to record before stopping.
+  EPISODE_DURATION_S:
+    type: int
+    default: 60
+    description: Episode length in seconds.
+  RESET_DURATION_S:
+    type: int
+    default: 15
+    description: Break in seconds between episodes to reset the environment.
+  USE_VIDEOS:
+    type: bool
+    default: true
+    description: Encode camera frames as MP4 video; otherwise store as images.
+  SAVE_AVIF_FRAMES:
+    type: bool
+    default: false
+    description: >-
+      Additionally save AVIF-encoded frames from rav1e_<camera> inputs to disk.
+  ROBOT_TYPE:
+    type: string
+    default: your_robot_type
+    description: Robot type recorded in the dataset metadata.
+  ROOT_PATH:
+    type: string
+    default: ""
+    description: >-
+      Local directory to store the dataset. Defaults to the LeRobot cache
+      location when empty.
+  IMAGE_WRITER_PROCESSES:
+    type: int
+    default: 0
+    description: Number of image-writer subprocesses used by LeRobot.
+  IMAGE_WRITER_THREADS:
+    type: int
+    default: 4
+    description: Image-writer threads per camera used by LeRobot.
+  PUSH_TO_HUB:
+    type: bool
+    default: false
+    description: Upload the dataset to the HuggingFace Hub when finished.
+  PRIVATE:
+    type: bool
+    default: false
+    description: Make the pushed dataset private (only used with PUSH_TO_HUB).
+  TAGS:
+    type: string
+    default: ""
+    description: Comma-separated tags attached to the dataset when pushing to Hub.
+
+example: |
+  - id: dataset-record
+    hub: dora-dataset-record@^0.5
+    inputs:
+      laptop: laptop-cam/image
+      front: front-cam/image
+      robot_state: robot-follower/pose
+      robot_action: leader-interface/pose
+    outputs:
+      - text
+    env:
+      REPO_ID: your_username/your_dataset_name
+      SINGLE_TASK: Pick up the cube and place it in the box
+      ROBOT_JOINTS: joint1,joint2,joint3,joint4,joint5,gripper
+      CAMERA_NAMES: laptop,front
+      CAMERA_LAPTOP_RESOLUTION: 480,640,3
+      CAMERA_FRONT_RESOLUTION: 480,640,3
+      FPS: 30
+      TOTAL_EPISODES: 50

--- a/node-hub/dora-llama-cpp-python/README.md
+++ b/node-hub/dora-llama-cpp-python/README.md
@@ -1,152 +1,61 @@
 # dora-llama-cpp-python
 
-A Dora node that provides access to LLaMA models using llama-cpp-python for efficient CPU/GPU inference.
+LLM text generation via [llama-cpp-python](https://github.com/abetlen/llama-cpp-python).
+Consumes input text and emits a generated response (text -> text) using a GGUF
+model, with optional CUDA (Linux) / Metal (macOS) GPU acceleration.
 
-## Features
+## Behavior
 
-- GPU acceleration support (CUDA on Linux, Metal on macOS)
-- Easy integration with speech-to-text and text-to-speech pipelines  
-- Configurable system prompts and activation words
-- Lightweight CPU inference with GGUF models
-- Thread-level CPU optimization
-- Adjustable context window size
+On startup the node loads a GGUF model: if `MODEL_NAME_OR_PATH` points at an
+existing local file it is loaded directly, otherwise the model is downloaded
+from HuggingFace using `MODEL_NAME_OR_PATH` as the repo id and
+`MODEL_FILE_PATTERN` to pick the file.
 
-## Getting started
+For each input event the node takes the first element of the value as the prompt
+text. If `ACTIVATION_WORDS` is set, the prompt is only answered when it contains
+at least one of those words; if it is empty, every input is answered. It then
+calls `create_chat_completion` (optionally prefixed by a `SYSTEM_PROMPT` message)
+and sends the generated content on the `text` output.
 
-### Installation
+## Inputs
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
-```
+- `text`: the prompt to generate a response for. The first array element is read
+  and used as the user message.
 
+## Outputs
+
+- `text`: the generated response string.
+
+## Environment variables
+
+- `SYSTEM_PROMPT` (string, default `""`): system prompt prepended to the chat. Empty means no system message.
+- `MODEL_NAME_OR_PATH` (string, default `TheBloke/Llama-2-7B-Chat-GGUF`): local GGUF path, or HuggingFace repo id to download.
+- `MODEL_FILE_PATTERN` (string, default `*Q4_K_M.gguf`): filename glob to select the GGUF file when downloading.
+- `MAX_TOKENS` (int, default `512`): maximum tokens generated per response.
+- `N_GPU_LAYERS` (int, default `0`): layers offloaded to GPU (e.g. `35` for full acceleration); `0` is CPU-only.
+- `N_THREADS` (int, default `4`): CPU threads used for inference.
+- `CONTEXT_SIZE` (int, default `4096`): maximum context window (`n_ctx`).
+- `ACTIVATION_WORDS` (string, default `""`): space-separated trigger words; when set, only prompts containing one are answered. Empty answers everything.
 
 ## Usage
 
-The node can be configured in your dataflow YAML file:
-
-```yaml
-
-# Using a HuggingFace model
-- id: dora-llama-cpp-python
-  build: pip install -e path/to/dora-llama-cpp-python
-  path: dora-llama-cpp-python
-  inputs:
-    text: source_node/text  # Input text to generate response for
-  outputs:
-    - text  # Generated response text
-  env:
-    MODEL_NAME_OR_PATH: "TheBloke/Llama-2-7B-Chat-GGUF"
-    MODEL_FILE_PATTERN: "*Q4_K_M.gguf"
-    SYSTEM_PROMPT: "You're a very succinct AI assistant with short answers."
-    ACTIVATION_WORDS: "what how who where you"
-    MAX_TOKENS: "512"
-    N_GPU_LAYERS: "35"     # Enable GPU acceleration
-    N_THREADS: "4"         # CPU threads
-    CONTEXT_SIZE: "4096"   # Maximum context window
-```
-
-### Configuration Options
-
-- `MODEL_NAME_OR_PATH`: Path to local model file or HuggingFace repo id (default: "TheBloke/Llama-2-7B-Chat-GGUF")
-- `MODEL_FILE_PATTERN`: Pattern to match model file when downloading from HF (default: "*Q4_K_M.gguf")
-- `SYSTEM_PROMPT`: Customize the AI assistant's personality/behavior
-- `ACTIVATION_WORDS`: Space-separated list of words that trigger model response
-- `MAX_TOKENS`: Maximum number of tokens to generate (default: 512)
-- `N_GPU_LAYERS`: Number of layers to offload to GPU (default: 0, set to 35 for GPU acceleration)
-- `N_THREADS`: Number of CPU threads to use (default: 4)
-- `CONTEXT_SIZE`: Maximum context window size (default: 4096)
-
-## Example: Speech Assistant Pipeline
-
-This example shows how to create a conversational AI pipeline that:
-1. Captures audio from microphone
-2. Converts speech to text
-3. Generates AI responses
-4. Converts responses back to speech
-
 ```yaml
 nodes:
-  - id: dora-microphone
-    build: pip install dora-microphone
-    path: dora-microphone
-    inputs:
-      tick: dora/timer/millis/2000
-    outputs:
-      - audio
-
-  - id: dora-vad
-    build: pip install dora-vad
-    path: dora-vad
-    inputs:
-      audio: dora-microphone/audio
-    outputs:
-      - audio
-      - timestamp_start
-
-  - id: dora-whisper
-    build: pip install dora-distil-whisper
-    path: dora-distil-whisper
-    inputs:
-      input: dora-vad/audio
-    outputs:
-      - text
-
   - id: dora-llama-cpp-python
-    build: pip install -e .
-    path: dora-llama-cpp-python
+    hub: dora-rs/dora-llama-cpp-python
     inputs:
-      text: dora-whisper/text
+      text: source-node/text
     outputs:
       - text
     env:
-      MODEL_NAME: "TheBloke/Llama-2-7B-Chat-GGUF"
+      MODEL_NAME_OR_PATH: TheBloke/Llama-2-7B-Chat-GGUF
       MODEL_FILE_PATTERN: "*Q4_K_M.gguf"
-      SYSTEM_PROMPT: "You're a helpful assistant."
-      ACTIVATION_WORDS: "hey help what how"
-      MAX_TOKENS: "512"
-      N_GPU_LAYERS: "35"
-      N_THREADS: "4"
-      CONTEXT_SIZE: "4096"
-
-  - id: dora-tts
-    build: pip install dora-kokoro-tts
-    path: dora-kokoro-tts
-    inputs:
-      text: dora-llama-cpp-python/text
-    outputs:
-      - audio
+      SYSTEM_PROMPT: "You're a very succinct AI assistant with short answers."
+      MAX_TOKENS: 512
 ```
 
-### Running the Example
+## Build
 
 ```bash
-dora build example.yml
-dora run example.yml
+pip install .
 ```
-
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
-
-```bash
-uv pip install ruff
-uv run ruff check . --fix
-```
-
-- Lint with ruff:
-
-```bash
-uv run ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-uv pip install pytest
-uv run pytest . # Test
-```
-
-## License
-
-dora-llama-cpp-python is released under the MIT License

--- a/node-hub/dora-llama-cpp-python/dora-node.yml
+++ b/node-hub/dora-llama-cpp-python/dora-node.yml
@@ -1,0 +1,67 @@
+apiVersion: 1
+name: dora-llama-cpp-python
+namespace: dora-rs
+description: LLM text generation via llama-cpp-python — consumes input text and emits a generated response (text -> text). Loads a GGUF model from a local path or HuggingFace, with optional CUDA/Metal GPU acceleration.
+categories: [llm]
+keywords: [llama, llama-cpp, gguf, llm, text-generation, chat]
+runtime: python
+entrypoint: dora-llama-cpp-python
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  text:
+    required: false
+    description: Prompt text to generate a response for; the first element of the Arrow array is read as the user message.
+
+outputs:
+  text:
+    description: Generated response text as a single-element UTF-8 Arrow array.
+
+env:
+  SYSTEM_PROMPT:
+    type: string
+    default: ""
+    description: System prompt prepended to the chat history. When empty, no system message is used.
+  MODEL_NAME_OR_PATH:
+    type: string
+    default: TheBloke/Llama-2-7B-Chat-GGUF
+    description: Local path to a GGUF model file, or a HuggingFace repo id to download from when the path does not exist.
+  MODEL_FILE_PATTERN:
+    type: string
+    default: "*Q4_K_M.gguf"
+    description: Filename glob used to select the GGUF file when downloading from HuggingFace.
+  MAX_TOKENS:
+    type: int
+    default: 512
+    description: Maximum number of tokens to generate per response.
+  N_GPU_LAYERS:
+    type: int
+    default: 0
+    description: Number of model layers to offload to the GPU (e.g. 35 for full GPU acceleration). 0 means CPU-only.
+  N_THREADS:
+    type: int
+    default: 4
+    description: Number of CPU threads used for inference.
+  CONTEXT_SIZE:
+    type: int
+    default: 4096
+    description: Maximum context window size (n_ctx) for the model.
+  ACTIVATION_WORDS:
+    type: string
+    default: ""
+    description: Space-separated trigger words. When set, a response is only generated if the input contains at least one of these words. When empty, every input is answered.
+
+example: |
+  - id: dora-llama-cpp-python
+    hub: dora-rs/dora-llama-cpp-python
+    inputs:
+      text: source-node/text
+    outputs:
+      - text
+    env:
+      MODEL_NAME_OR_PATH: TheBloke/Llama-2-7B-Chat-GGUF
+      MODEL_FILE_PATTERN: "*Q4_K_M.gguf"
+      SYSTEM_PROMPT: "You're a very succinct AI assistant with short answers."
+      MAX_TOKENS: 512

--- a/node-hub/dora-mujoco-husky/README.md
+++ b/node-hub/dora-mujoco-husky/README.md
@@ -1,107 +1,63 @@
 # dora-mujoco-husky
 
-A MuJoCo-based Clearpath Husky simulation node for the Dora framework. This node provides a physics-accurate simulation of the Husky robot that can be controlled via velocity commands.
+A MuJoCo-based Clearpath Husky mobile-robot simulation node. It consumes
+velocity commands, steps a physics-accurate Husky model, and emits the robot's
+position and velocity feedback.
 
-## Features
+## Behavior
 
-- Real-time physics simulation using MuJoCo
-- Accurate Husky robot model with proper inertial properties
-- Velocity-based control interface
-- Position and velocity feedback
-- Gamepad control support
+On startup the node downloads the required Husky meshes, loads the
+`husky/husky.xml` MuJoCo model, and opens a passive viewer window.
 
-## Getting Started
+For each `cmd_vel` input it:
 
-### Prerequisites
+- reads linear velocity from index 0 (clamped to [-2.0, 2.0] m/s) and angular
+  velocity from index 5 (clamped to [-3.0, 3.0] rad/s),
+- converts them to left/right wheel velocities (wheel radius 0.17775 m, track
+  width 0.59 m) and applies them to the four wheel actuators,
+- advances the simulation one step and syncs the viewer,
+- emits the base `position` (qpos[:3]) and `velocity` (qvel[:3]).
 
-- Python 3.8 or higher
-- MuJoCo 3.1.6 or higher
+Inputs other than `cmd_vel` are ignored.
 
-### Installation
+## Inputs
 
-1. Create and activate a Python virtual environment:
-```bash
-uv venv -p 3.11 --seed
-source .venv/bin/activate
-```
+- `cmd_vel`: velocity command array. Index 0 = linear velocity (m/s, clamped to
+  [-2.0, 2.0]); index 5 = angular velocity (rad/s, clamped to [-3.0, 3.0]).
 
-2. Install the package:
-```bash 
-uv pip install -e .
-```
+## Outputs
 
-### Running the Demo
+- `position`: base position `[x, y, z]` from MuJoCo `qpos`, float64.
+- `velocity`: base velocity `[vx, vy, vz]` from MuJoCo `qvel`, float64.
 
-1. Make sure you have a gamepad connected
-2. Build the demo:
-```bash
-dora build demo.yml --uv
-```
-3. Run the demo:
-```bash
-dora run demo.yml --uv
-```
+## Environment variables
+
+None.
 
 ## Usage
 
-The node accepts velocity commands and outputs position/velocity data:
-
-### Inputs
-
-- `cmd_vel`: Velocity command array with the format:
-  - Index 0: Linear velocity (m/s), range: [-2.0, 2.0]
-  - Index 5: Angular velocity (rad/s), range: [-3.0, 3.0]
-
-### Outputs
-
-- `position`: Robot position [x, y, z] in world coordinates
-- `velocity`: Robot velocity [vx, vy, vz] in world coordinates
-
-### Example Configuration
+Drive the sim from a gamepad and inspect its output:
 
 ```yaml
 nodes:
-  - id: mujoco_husky
-    build: pip install -e .
-    path: dora-mujoco-husky
+  - id: gamepad
+    hub: gamepad@^0.5
     inputs:
-      cmd_vel: input_source/cmd_vel
+      tick: dora/timer/millis/10
+    outputs:
+      - cmd_vel
+
+  - id: mujoco_husky
+    hub: dora-mujoco-husky@^0.5
+    inputs:
+      cmd_vel: gamepad/cmd_vel
     outputs:
       - position
       - velocity
 ```
 
-## Development
+## Build
 
-### Code Formatting
-
-Format code using ruff:
 ```bash
-uv pip install ruff
-uv run ruff check . --fix
+pip install .
 ```
-
-### Linting
-
-Run linting checks:
-```bash
-uv run ruff check .
-```
-
-### Testing
-
-Run tests using pytest:
-```bash
-uv pip install pytest
-uv run pytest .
-```
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## Acknowledgments
-
-- Based on the Clearpath Robotics Husky robot
-- Uses the MuJoCo physics engine
-- Built with the Dora framework

--- a/node-hub/dora-mujoco-husky/dora-node.yml
+++ b/node-hub/dora-mujoco-husky/dora-node.yml
@@ -1,0 +1,41 @@
+apiVersion: 1
+name: dora-mujoco-husky
+namespace: dora-rs
+description: MuJoCo-based Clearpath Husky mobile-robot simulation node. Consumes velocity commands, steps the physics sim, and emits the robot's position and velocity.
+categories: [simulator, robot]
+keywords: [mujoco, husky, simulation, mobile-robot, physics]
+runtime: python
+entrypoint: dora-mujoco-husky
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  cmd_vel:
+    required: false
+    description: Velocity command array; index 0 is linear velocity (m/s, clamped to [-2.0, 2.0]), index 5 is angular velocity (rad/s, clamped to [-3.0, 3.0]).
+
+outputs:
+  position:
+    description: Robot base position [x, y, z] from MuJoCo qpos, as float64.
+  velocity:
+    description: Robot base velocity [vx, vy, vz] from MuJoCo qvel, as float64.
+
+env: {}
+
+example: |
+  nodes:
+    - id: gamepad
+      hub: gamepad@^0.5
+      inputs:
+        tick: dora/timer/millis/10
+      outputs:
+        - cmd_vel
+
+    - id: mujoco_husky
+      hub: dora-mujoco-husky@^0.5
+      inputs:
+        cmd_vel: gamepad/cmd_vel
+      outputs:
+        - position
+        - velocity

--- a/node-hub/dora-mujoco/README.md
+++ b/node-hub/dora-mujoco/README.md
@@ -1,235 +1,73 @@
 # dora-mujoco
 
-A MuJoCo physics simulation node for the Dora dataflow framework. This node provides real-time physics simulation with support for a wide range of robots from the `robot_descriptions` package, as well as custom robot models. Designed for modular robotics control architectures.
+A MuJoCo physics simulation node for the Dora dataflow framework. It loads a
+robot model, steps the physics once per received event, applies actuator
+control inputs, and emits joint and sensor state.
 
-## Features
+## Behavior
 
-- **Wide Robot Support**: Built-in support for 50+ robot models including quadrupeds, humanoids, arms, drones, and more
-- **Flexible Model Loading**: Load robots by name (via robot_descriptions) or direct XML file paths
-- **Real-time Simulation**: Continuous physics simulation with configurable tick rates
-- **Live Visualization**: Optional MuJoCo viewer for real-time 3D visualization
-- **Generic Control Interface**: Accepts control commands for any robot type
-- **Rich Data Output**: Joint positions, velocities, accelerations, and sensor data
+On startup the node loads a model named by the `MODEL_NAME` environment
+variable. If `MODEL_NAME` is a path to an existing `.xml` file it is loaded
+directly; otherwise it is treated as a `robot_descriptions` name and loaded with
+its `scene` variant. The model is reset to its first keyframe (or to zero if it
+has none), and a passive MuJoCo viewer is launched for live visualization.
 
+The node then runs the Dora event loop. For every event it receives it steps the
+physics simulation once and syncs the viewer. When the event is an input, after
+stepping it emits the current state (`joint_positions`, `joint_velocities`,
+`actuator_controls`, and `sensor_data` when the model has sensors). A
+`control_input` event additionally applies its values to the model's actuators
+before the step — each value is clamped to that actuator's control range, and
+values beyond the actuator count are ignored.
 
-## Supported Robot Categories
+## Inputs
 
-| Category | Examples |
-|----------|----------|
-| **Quadrupeds** | Unitree Go1/Go2/A1, ANYmal B/C, Boston Dynamics Spot |
-| **Humanoids** | Unitree G1/H1, Apptronik Apollo, TALOS, JVRC-1 |
-| **Arms** | Franka Panda, KUKA iiwa14, Universal Robots UR5e/UR10e |
-| **Dual Arms** | Aloha 2, Baxter, YuMi |
-| **End Effectors** | Allegro Hand, Shadow Hand, Robotiq 2F-85 |
-| **Drones** | Crazyflie 2.0, Skydio X2 |
-| **Educational** | Double Pendulum |
+- `tick` (required): drives the simulation. Each received event steps the
+  physics once and triggers the state outputs. Wire to a timer such as
+  `dora/timer/millis/2` for ~500 Hz.
+- `control_input` (optional): actuator commands as a float64 Arrow array,
+  applied in actuator order and clamped to each actuator's control range.
 
-## Getting Started
+## Outputs
 
-### Quick Start
+- `joint_positions`: joint positions (MuJoCo `qpos`), float64 Arrow array.
+  Metadata: `timestamp`, `encoding: jointstate`.
+- `joint_velocities`: joint velocities (MuJoCo `qvel`), float64 Arrow array.
+  Metadata: `timestamp`.
+- `actuator_controls`: current actuator commands (MuJoCo `ctrl`), float64 Arrow
+  array. Metadata: `timestamp`.
+- `sensor_data`: sensor readings (MuJoCo `sensordata`), float64 Arrow array.
+  Emitted only when the model defines sensors. Metadata: `timestamp`.
 
-1. **Run a simple simulation**:
-```bash
-dora build demo.yml 
-# Start with Unitree Go2 quadruped
-dora run demo.yml
-```
+## Environment variables
 
-2. **Use different robots**:
-```python
-# In main.py, modify the model name (line ~95)
-model_path_or_name = "franka_panda"  # Change this line
-# Examples: "go2", "franka_panda", "g1", "spot", etc.
-```
+- `MODEL_NAME` (default `go2_mj_description`): robot to load — a
+  `robot_descriptions` name (loaded as its `scene` variant) or a path to a
+  MuJoCo `.xml` model file.
 
-3. **Use custom robot models**:
-```python
-# In main.py, use file path instead of model name
-model_path_or_name = "/path/to/my_robot/scene.xml"
-```
+## Usage
 
-## Usage Examples
-TODO
+Drive the simulation with a timer and (optionally) wire a controller into
+`control_input`:
 
-### Available Robot Models
-The simulator supports all models from the `robot_descriptions` package. Common names include:
-
-- **Quadrupeds**: `go1`, `go2`, `a1`, `aliengo`, `anymal_b`, `anymal_c`, `spot`
-- **Humanoids**: `g1`, `h1`, `apollo`, `talos`, `jvrc`, `cassie`
-- **Arms**: `panda`, `ur5e`, `ur10e`, `iiwa14`, `gen3`, `sawyer`
-- **Hands**: `allegro_hand`, `shadow_hand`, `leap_hand`, `robotiq_2f85`
-
-See [`robot_models.json`](dora_mujoco/robot_models.json) for the complete list.
-
-## Architecture
-
-The `dora-mujoco` node is designed to be **robot-agnostic** and work with **robot-specific controllers**:
-
-```
-┌─────────────────┐    
-│  Command Node   │    target_pose/cmd_vel
-│  (Gamepad, etc) │─────────────┐
-└─────────────────┘             │
-                                ▼
-┌─────────────────┐    control_input   ┌─────────────────┐
-│ Robot Controller│───────────────────▶│  dora-mujoco    │
-│ (Franka, Husky) │                    │                 │
-└─────────────────┘                    │ ┌─────────────┐ │    joint_positions
-           ▲                           │ │  Simulator  │ │──────────────────▶
-           │        joint_positions    │ │             │ │    joint_velocities  
-           └───────────────────────────│ │  ┌────────┐ │ │──────────────────▶
-                                       │ │  │Renderer│ │ │    actuator_controls
-                                       │ │  └────────┘ │ │──────────────────▶
-                                       │ │             │ │    sensor_data
-                                       │ └─────────────┘ │──────────────────▶
-                                       └─────────────────┘
-the control nodes are optional (the robot will still spawn without them)
-```
-
-## YAML Specification
-
-### Node Configuration
 ```yaml
 nodes:
-  - id: mujoco_sim
-    build: pip install -e .
-    path: dora-mujoco
-    env:
-      MODEL_NAME: "go2"  # Robot model name or file path
+  - id: mujoco-sim
+    hub: dora-mujoco@^0.5
     inputs:
-      TICK: dora/timer/millis/2  # Simulation tick rate (500Hz)
+      tick: dora/timer/millis/2
+      control_input: controller/output
     outputs:
-      - joint_positions    # Joint position array
-      - joint_velocities   # Joint velocity array  
-      - sensor_data       # Sensor readings array
+      - joint_positions
+      - joint_velocities
+      - actuator_controls
+      - sensor_data
+    env:
+      MODEL_NAME: go2_mj_description
 ```
 
-### Input Specification
-| Input | Type | Description |
-|-------|------|-------------|
-| `tick` | Timer | Triggers simulation steps and data output |
-| `control_input` | `pa.array(float64)` | Control commands for actuators |
+## Build
 
-**Control Input Format**:
-- **Manipulator Arms**: Joint position commands `[q1, q2, ..., q7, gripper]`
-- **Mobile Robots**: Wheel velocity commands `[wheel1, wheel2, wheel3, wheel4]`
-- **Quadrupeds**: Joint position commands `[hip1, thigh1, calf1, ...]`
-
-### Output Specification
-| Output | Type | Description | Metadata |
-|--------|------|-------------|----------|
-| `joint_positions` | `pa.array(float64)` | Joint positions (qpos) | `timestamp` |
-| `joint_velocities` | `pa.array(float64)` | Joint velocities (qvel) | `timestamp` |
-| `actuator_controls` | `pa.array(float64)` | Current actuator commands | `timestamp` |
-| `sensor_data` | `pa.array(float64)` | Sensor readings (if available) | `timestamp` |
-
-## Configuration Options
-
-### Environment Variables
-- `MODEL_NAME`: Robot model name or XML file path (default: "go2")
-
-### Custom Robot Models
-```python
-# Use direct XML file path
-env:
-  MODEL_NAME: "/path/to/my_robot/scene.xml"
-```
-
-### Simulation Parameters
-- **Physics Timestep**: Fixed at MuJoCo default (0.002s = 500Hz)
-- **Output Rate**: Controlled by `tick` input frequency
-- **Control Rate**: Determined by `control_input` frequency
-
-## Development
-
-### Code Quality
 ```bash
-# Format code
-uv run ruff check . --fix
-
-# Lint code  
-uv run ruff check .
-
-# Run tests
-uv pip install pytest
-uv run pytest .
+pip install .
 ```
-
-### Adding New Models
-To add support for new robot models:
-
-1. Add the model mapping to [`robot_models.json`](dora_mujoco/robot_models.json):
-```json
-{
-  "category_name": {
-    "my_robot": "my_robot_mj_description"
-  }
-}
-```
-
-2. Ensure the model is available in `robot_descriptions` or provide the XML file path directly.
-
-### Creating Robot Controllers
-
-Robot-specific controllers should:
-1. Subscribe to `joint_positions` from the simulation
-2. Implement robot-specific control logic (IK, dynamics, etc.)
-3. Publish `control_input` commands to the simulation
-
-
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Model not found**:
-   ```
-   ERROR: Model file not found for my_robot
-   ```
-   - Check if the model name exists in `robot_models.json`
-   - Verify `robot_descriptions` has the model installed
-   - Use absolute file path for custom models
-
-2. **Scene variant missing**:
-   ```
-   WARNING: Failed to load scene variant
-   ```
-   - Normal behavior - falls back to robot-only model
-   - Scene variants include ground plane and lighting
-
-3. **Control dimension mismatch**:
-   ```
-   WARNING: Control input size doesn't match actuators
-   ```
-   - Check that control commands match the robot's actuator count
-   - Use `print(model.nu)` to see expected control dimensions
-
-4. **Viewer issues**:
-   - Ensure proper OpenGL/graphics drivers
-   - Use headless mode for server environments
-
-## Examples
-
-Complete working examples are available in:
-- `dora/examples/mujoco-sim/`
-  - Target pose control with Cartesian space control
-  - Gamepad control with real-time interaction
-
-## License
-
-This project is released under the MIT License. See the LICENSE file for details.
-
-## Contributing
-
-Contributions are welcome! Please:
-
-1. Follow the existing code style (ruff formatting)
-2. Add tests for new features
-3. Update documentation as needed
-4. Submit pull requests with clear descriptions
-
-## Related Projects
-
-- [Dora-rs](https://github.com/dora-rs/dora) - The dataflow framework
-- [MuJoCo](https://github.com/google-deepmind/mujoco) - Physics simulation engine  
-- [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions) - Robot model collection

--- a/node-hub/dora-mujoco/dora-node.yml
+++ b/node-hub/dora-mujoco/dora-node.yml
@@ -1,0 +1,64 @@
+apiVersion: 1
+name: dora-mujoco
+namespace: dora-rs
+description: >-
+  MuJoCo physics simulation node — loads a robot model, steps physics on each
+  tick, applies actuator control inputs, and emits joint/sensor state.
+categories: [simulator, robot]
+keywords: [simulation, mujoco, physics, robot, robot-descriptions]
+runtime: python
+entrypoint: dora-mujoco
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  tick:
+    required: true
+    description: >-
+      Drives the simulation. Each received event steps the physics once and
+      emits the current state outputs. Wire to a timer, e.g.
+      `dora/timer/millis/2` for ~500 Hz.
+  control_input:
+    required: false
+    description: >-
+      Actuator commands as a float64 Arrow array. Applied to the model's
+      actuators in order (clamped to each actuator's control range); extra
+      values beyond the actuator count are ignored.
+outputs:
+  joint_positions:
+    description: >-
+      Joint positions (MuJoCo `qpos`) as a float64 Arrow array. Metadata
+      carries `timestamp` (simulation time) and `encoding: jointstate`.
+  joint_velocities:
+    description: >-
+      Joint velocities (MuJoCo `qvel`) as a float64 Arrow array. Metadata
+      carries `timestamp` (simulation time).
+  actuator_controls:
+    description: >-
+      Current actuator commands (MuJoCo `ctrl`) as a float64 Arrow array.
+      Metadata carries `timestamp` (simulation time).
+  sensor_data:
+    description: >-
+      Sensor readings (MuJoCo `sensordata`) as a float64 Arrow array. Emitted
+      only when the model defines sensors. Metadata carries `timestamp`
+      (simulation time).
+env:
+  MODEL_NAME:
+    type: string
+    default: go2_mj_description
+    description: >-
+      Robot to load — a `robot_descriptions` name (the `scene` variant is
+      loaded) or a path to a MuJoCo `.xml` model file.
+example: |
+  - id: mujoco-sim
+    hub: dora-mujoco@^0.5
+    inputs:
+      tick: dora/timer/millis/2
+      control_input: controller/output
+    outputs:
+      - joint_positions
+      - joint_velocities
+      - actuator_controls
+      - sensor_data
+    env:
+      MODEL_NAME: go2_mj_description

--- a/node-hub/dora-policy-inference/README.md
+++ b/node-hub/dora-policy-inference/README.md
@@ -1,29 +1,54 @@
 # dora-policy-inference
 
-Load pre-trained policies and execute them in real-time to control robots based on camera observations and current robot state.
+Load a pre-trained LeRobot policy and run it in real time to control a robot
+from camera observations and the current robot joint state.
 
-## Quick Start
+## Behavior
 
-### 1. Installation
+The node loads a LeRobot policy from `MODEL_PATH` on startup (device — CUDA / MPS
+/ CPU — is selected automatically by LeRobot) and buffers every input it
+receives. The camera input ids are taken from `CAMERA_NAMES` (default
+`laptop,front`); the **first** camera in that list is the lead camera.
 
-```bash
-# Source your venv
-cd dora/node-hub/dora-policy-inference
-uv pip install -e .
-```
+When the lead camera input arrives — and at most once per `1 / INFERENCE_FPS`
+seconds — the node assembles an observation from the buffered camera images
+(`observation.images.<camera>`) and the robot state (`observation.state`), runs
+the policy, converts the predicted action from degrees to radians, and emits it
+on `robot_action`. Camera images are reshaped from the input's `height`/`width`
+metadata and color-converted per the `encoding` metadata (`bgr8`, `yuv420`).
+Robot state is converted from radians to degrees and float32 before inference.
 
-### 2. Usage Guide
+## Inputs
 
-Create a dataflow file, see `examples/lerobot-dataset/policy_inference.yml`:
+- `laptop`: lead camera image (Arrow uint8). Its arrival triggers inference.
+  Must match the first entry of `CAMERA_NAMES`.
+- `front`: secondary camera image (Arrow uint8). Must match an entry of
+  `CAMERA_NAMES`. Add one input per camera you list.
+- `robot_state`: current robot joint state in radians (Arrow numeric).
+
+Image inputs rely on `height`, `width`, and optional `encoding` metadata.
+
+## Outputs
+
+- `robot_action`: predicted robot action, converted to radians.
+- `status`: status / log messages (e.g. "Policy loaded successfully").
+
+## Environment variables
+
+| Variable           | Type   | Default        | Description                                                              |
+| ------------------ | ------ | -------------- | ------------------------------------------------------------------------ |
+| `MODEL_PATH`       | string | (required)     | Trained LeRobot policy model directory.                                  |
+| `CAMERA_NAMES`     | string | `laptop,front` | Comma-separated camera input ids; first is the lead (inference trigger). |
+| `TASK_DESCRIPTION` | string | `""`           | Task string for task-conditioned policies.                               |
+| `INFERENCE_FPS`    | int    | `30`           | Max inference frequency (Hz).                                            |
+
+## Usage
 
 ```yaml
 nodes:
-  # Policy inference
-  - id: policy_inference
-    build: pip install -e ../../dora-policy-inference
-    path: dora-policy-inference
+  - id: dora-policy-inference
+    hub: dora-policy-inference@^0.5
     inputs:
-      # your Cameras should be same as the dataset trained policy is on.
       laptop: laptop_cam/image
       front: front_cam/image
       robot_state: robot/pose
@@ -31,76 +56,21 @@ nodes:
       - robot_action
       - status
     env:
-      # Required settings
-      MODEL_PATH: "/path/to/your/lerobot/model"
-      TASK_DESCRIPTION: "pick up the cup"
-      INFERENCE_FPS: "30"
-
-      # Camera configuration
+      MODEL_PATH: /path/to/your/lerobot/model
       CAMERA_NAMES: "laptop,front"
-      CAMERA_LAPTOP_RESOLUTION: "480,640,3"
-      CAMERA_FRONT_RESOLUTION: "480,640,3"
+      TASK_DESCRIPTION: "pick up the cup"
+      INFERENCE_FPS: 30
 
-  # Robot controller
   - id: robot_controller
     path: your-robot-controller
     inputs:
-      action: policy_inference/robot_action # predicted joint state(rad)
+      action: dora-policy-inference/robot_action
     outputs:
       - pose
 ```
 
-### 3. Start Policy Inference
+## Build
 
 ```bash
-dora build policy_inference.yml
-dora run policy_inference.yml
+pip install .
 ```
-
-The node will process camera inputs and robot state to generate actions for robot control.
-
-## Configuration
-
-### Required Environment Variables
-
-| Variable              | Description                                        | Example                                                         |
-| --------------------- | -------------------------------------------------- | --------------------------------------------------------------- |
-| `MODEL_PATH`          | Path to trained LeRobot policy model directory     | `"outputs/train/your_policy/checkpoints/last/pretrained_model"` |
-| `CAMERA_NAMES`        | Comma-separated camera names                       | `"laptop,front,top"`                                            |
-| `CAMERA_*_RESOLUTION` | Resolution for each camera (height,width,channels) | `"480,640,3"`                                                   |
-| `INFERENCE_FPS`       | Inference frequency                                | `"30"`                                                          |
-| `TASK_DESCRIPTION`    | Task description for task-conditioned policies     | `"Grab the red cube and and drop in the box."`                  |
-
-## Camera Configuration
-
-For each camera defined in `CAMERA_NAMES`, you must set the resolution:
-
-```bash
-export CAMERA_NAMES="laptop,front,top"
-export CAMERA_LAPTOP_RESOLUTION="1080,1920,3"
-export CAMERA_FRONT_RESOLUTION="480,640,3"
-export CAMERA_TOP_RESOLUTION="480,640,3"
-```
-
-## Model Requirements
-
-The node expects LeRobot trained models with:
-
-- A `config.json` file in the model directory
-- Model weights compatible with LeRobot's `from_pretrained()` method
-
-#### Device Selection
-
-The node automatically selects the best available device:
-
-- CUDA GPU (if available)
-- MPS (Apple Silicon)
-- CPU (fallback)
-
-Device selection is handled by LeRobot's `get_safe_torch_device()` function.
-
-> See the `examples/lerobot-dataset/policy_inference.yml` for complete dataflow configurations.
-
-## License
-
-This project is released under the MIT License.

--- a/node-hub/dora-policy-inference/README.md
+++ b/node-hub/dora-policy-inference/README.md
@@ -23,7 +23,9 @@ Robot state is converted from radians to degrees and float32 before inference.
 - `laptop`: lead camera image (Arrow uint8). Its arrival triggers inference.
   Must match the first entry of `CAMERA_NAMES`.
 - `front`: secondary camera image (Arrow uint8). Must match an entry of
-  `CAMERA_NAMES`. Add one input per camera you list.
+  `CAMERA_NAMES`. To use more cameras, add each to `CAMERA_NAMES` **and** declare
+  a matching input in this node's manifest — the hub contract rejects camera ids
+  that aren't declared, so extending `CAMERA_NAMES` alone is not enough.
 - `robot_state`: current robot joint state in radians (Arrow numeric).
 
 Image inputs rely on `height`, `width`, and optional `encoding` metadata.

--- a/node-hub/dora-policy-inference/dora-node.yml
+++ b/node-hub/dora-policy-inference/dora-node.yml
@@ -23,7 +23,9 @@ inputs:
     description: >-
       Secondary camera image observation (Arrow uint8, reshaped via metadata
       height/width to H x W x 3). The input id must match an entry of
-      CAMERA_NAMES. Add one input per camera listed in CAMERA_NAMES.
+      CAMERA_NAMES. To use more cameras, add each one to CAMERA_NAMES AND
+      declare a matching input here — the hub contract rejects camera ids that
+      are not declared in this manifest, so extending CAMERA_NAMES alone fails.
   robot_state:
     description: >-
       Current robot joint state in radians (Arrow numeric). Converted to degrees

--- a/node-hub/dora-policy-inference/dora-node.yml
+++ b/node-hub/dora-policy-inference/dora-node.yml
@@ -1,0 +1,75 @@
+apiVersion: 1
+name: dora-policy-inference
+namespace: dora-rs
+description: >-
+  LeRobot policy inference node. Buffers camera image observations and robot
+  state, runs a pre-trained LeRobot policy when the lead camera ticks, and emits
+  the predicted robot action (in radians).
+categories: [ml-inference, robot]
+keywords: [lerobot, policy, inference, imitation-learning, robot-control]
+runtime: python
+entrypoint: dora-policy-inference
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  laptop:
+    description: >-
+      Lead camera image observation (Arrow uint8, reshaped via metadata
+      height/width to H x W x 3). Receiving this input triggers inference. The
+      input id must match the first entry of CAMERA_NAMES.
+  front:
+    description: >-
+      Secondary camera image observation (Arrow uint8, reshaped via metadata
+      height/width to H x W x 3). The input id must match an entry of
+      CAMERA_NAMES. Add one input per camera listed in CAMERA_NAMES.
+  robot_state:
+    description: >-
+      Current robot joint state in radians (Arrow numeric). Converted to degrees
+      and float32 before being passed to the policy as observation.state.
+
+outputs:
+  robot_action:
+    description: Predicted robot action, converted from degrees to radians.
+  status:
+    description: Status / log messages emitted by the node (e.g. policy loaded).
+
+env:
+  MODEL_PATH:
+    type: string
+    description: >-
+      Path to the trained LeRobot policy model directory (loaded via
+      PreTrainedConfig.from_pretrained). Required.
+  CAMERA_NAMES:
+    type: string
+    default: "laptop,front"
+    description: >-
+      Comma-separated camera input ids. The first name is the lead camera that
+      triggers inference; each name must be wired as an input.
+  TASK_DESCRIPTION:
+    type: string
+    default: ""
+    description: Task description string passed to task-conditioned policies.
+  INFERENCE_FPS:
+    type: int
+    default: 30
+    description: >-
+      Maximum inference frequency; inference is skipped if the lead camera ticks
+      faster than 1/INFERENCE_FPS seconds since the last run.
+
+example: |
+  - id: dora-policy-inference
+    hub: dora-policy-inference@^0.5
+    inputs:
+      laptop: laptop_cam/image
+      front: front_cam/image
+      robot_state: robot/pose
+    outputs:
+      - robot_action
+      - status
+    env:
+      MODEL_PATH: /path/to/your/lerobot/model
+      CAMERA_NAMES: "laptop,front"
+      TASK_DESCRIPTION: "pick up the cup"
+      INFERENCE_FPS: 30

--- a/node-hub/dora-qwen2-5-vl/README.md
+++ b/node-hub/dora-qwen2-5-vl/README.md
@@ -36,6 +36,10 @@ The generated text is sent on the `text` output.
   is treated as text — a UTF-8 string array. Empty values fall back to the
   cached question.
 
+When run via `hub:`, wire these on the declared ids `image` and `text`: the
+substring match only adds flexibility for `path:` dataflows, but the hub
+contract permits only declared input ids.
+
 ## Outputs
 
 - `text`: the generated UTF-8 text response (a single-element string array),

--- a/node-hub/dora-qwen2-5-vl/README.md
+++ b/node-hub/dora-qwen2-5-vl/README.md
@@ -1,31 +1,82 @@
-# Dora QwenVL2.5 node
+# dora-qwen2-5-vl
 
-Experimental node for using a VLM within dora.
+A Qwen2.5-VL vision-language node: it takes camera/image frames plus a text
+prompt and emits a generated text response.
 
-## YAML Specification
+## Behavior
 
-This node is supposed to be used as follows:
+The node loads a `Qwen2_5_VLForConditionalGeneration` model (id or path from
+`MODEL_NAME_OR_PATH`) and connects as a dora node. Device is selected
+automatically: MPS on Apple Silicon, CUDA when available, otherwise CPU. If
+`flash_attn` is installed it is used; otherwise it falls back to the default
+attention. An optional PEFT adapter is loaded when `ADAPTER_PATH` is set.
+
+For each event:
+
+- An input whose id **contains** `image` is decoded into a PIL image. Raw
+  `bgr8`/`rgb8` buffers are reshaped from metadata `width`/`height`; encoded
+  `jpeg`/`jpg`/`jpe`/`bmp`/`webp`/`png` payloads are decoded with OpenCV. The
+  latest frame per input id is cached. Any other encoding raises an error.
+- An input whose id **contains** `text` triggers generation. The text strings
+  (or the cached `DEFAULT_QUESTION` when empty) are turned into chat messages
+  along with the cached image(s), and the model generates up to 128 new tokens.
+  When `ACTIVATION_WORDS` is set, generation is skipped unless an incoming word
+  matches. Special prefixes (`<|system|>`, `<|assistant|>`, `<|tool|>`,
+  `<|user|>...`) are parsed into chat roles. With `HISTORY` enabled the
+  conversation is retained across turns.
+
+The generated text is sent on the `text` output.
+
+## Inputs
+
+- `image`: image frames to describe. Any input id containing `image` is treated
+  as an image — raw `bgr8`/`rgb8` buffer or encoded `jpeg`/`jpg`/`jpe`/`bmp`/
+  `webp`/`png` byte array, with metadata `encoding`/`width`/`height`.
+- `text`: text prompt(s) that trigger generation. Any input id containing `text`
+  is treated as text — a UTF-8 string array. Empty values fall back to the
+  cached question.
+
+## Outputs
+
+- `text`: the generated UTF-8 text response (a single-element string array),
+  with metadata `image_id` and `primitive` = `text`.
+
+## Environment variables
+
+- `MODEL_NAME_OR_PATH` (string, default `Qwen/Qwen2.5-VL-3B-Instruct`): model id
+  or local path to load.
+- `USE_MODELSCOPE_HUB` (bool, default `false`): download from ModelScope instead
+  of Hugging Face.
+- `SYSTEM_PROMPT` (string, default `You're a very succinct AI assistant, that
+  describes image with a very short sentence.`): seeded as the first message.
+- `ACTIVATION_WORDS` (string, default empty): space-separated words; when set,
+  generation only runs when an incoming text contains one of them.
+- `DEFAULT_QUESTION` (string, default `Describe this image`): used when a text
+  input arrives empty.
+- `IMAGE_RESIZE_RATIO` (float, default `1.0`): multiplier applied to image
+  width/height before inference.
+- `HISTORY` (bool, default `false`): keep conversation history across turns.
+- `ADAPTER_PATH` (string, default empty): optional PEFT/LoRA adapter to load.
+
+## Usage
 
 ```yaml
-- id: dora-qwenvl
-  build: pip install dora-qwen2-5-vl
-  path: dora-qwen2-5-vl
-  inputs:
-    image:
-      source: camera/image
-      queue_size: 1
-    text: dora-distil-whisper/text
-  outputs:
-    - text
-  env:
-    DEFAULT_QUESTION: Describe the image in a very short sentence.
+nodes:
+  - id: dora-qwen2-5-vl
+    hub: dora-qwen2-5-vl@^0.5
+    inputs:
+      image:
+        source: camera/image
+        queue_size: 1
+      text: whisper/text
+    outputs:
+      - text
+    env:
+      DEFAULT_QUESTION: Describe the image in a very short sentence.
 ```
 
-## Additional documentation
+## Build
 
-- Qwenvl: https://github.com/QwenLM/Qwen-VL
-
-## Examples
-
-- Vision Language Model
-  - Github: https://github.com/dora-rs/dora-hub/blob/main/examples/vlm
+```bash
+pip install .
+```

--- a/node-hub/dora-qwen2-5-vl/dora-node.yml
+++ b/node-hub/dora-qwen2-5-vl/dora-node.yml
@@ -1,0 +1,72 @@
+apiVersion: 1
+name: dora-qwen2-5-vl
+namespace: dora-rs
+description: Qwen2.5-VL vision-language node — takes images and text prompts and emits a generated text response.
+categories: [ml-inference, llm]
+keywords: [qwen, vlm, vision-language, image-captioning, transformers]
+runtime: python
+entrypoint: dora-qwen2-5-vl
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    required: false
+    description: >-
+      Image frames to describe. Any input id containing "image" is treated as an image; payload is a raw bgr8/rgb8 buffer or an encoded jpeg/jpg/jpe/bmp/webp/png byte array, with metadata encoding/width/height.
+  text:
+    required: false
+    description: >-
+      Text prompt(s) that trigger generation. Any input id containing "text" is treated as text; a UTF-8 string array. Empty values fall back to the cached question.
+
+outputs:
+  text:
+    description: Generated UTF-8 text response (a single-element string array), with metadata image_id and primitive=text.
+
+env:
+  MODEL_NAME_OR_PATH:
+    type: string
+    default: "Qwen/Qwen2.5-VL-3B-Instruct"
+    description: Hugging Face / ModelScope model id or local path to load.
+  USE_MODELSCOPE_HUB:
+    type: bool
+    default: false
+    description: When true, download the model from ModelScope instead of Hugging Face.
+  SYSTEM_PROMPT:
+    type: string
+    default: "You're a very succinct AI assistant, that describes image with a very short sentence."
+    description: System prompt seeded as the first message in the conversation history.
+  ACTIVATION_WORDS:
+    type: string
+    default: ""
+    description: Space-separated words; if set, generation only runs when an incoming text contains one of them.
+  DEFAULT_QUESTION:
+    type: string
+    default: "Describe this image"
+    description: Question used when a text input arrives with an empty value.
+  IMAGE_RESIZE_RATIO:
+    type: float
+    default: 1.0
+    description: Multiplier applied to image width/height before inference.
+  HISTORY:
+    type: bool
+    default: false
+    description: When true, keep conversation history across turns by appending each response.
+  ADAPTER_PATH:
+    type: string
+    default: ""
+    description: Optional path to a PEFT/LoRA adapter to load onto the base model.
+
+example: |
+  - id: dora-qwen2-5-vl
+    hub: dora-qwen2-5-vl@^0.5
+    inputs:
+      image:
+        source: camera/image
+        queue_size: 1
+      text: whisper/text
+    outputs:
+      - text
+    env:
+      DEFAULT_QUESTION: Describe the image in a very short sentence.

--- a/node-hub/dora-reachy2/README.md
+++ b/node-hub/dora-reachy2/README.md
@@ -1,4 +1,4 @@
-# dora-reachy2
+# dora-reachy2-camera
 
 Camera node for the Reachy 2 robot package — streams stereo teleop (left/right)
 and depth frames from a Reachy 2 over the network. This Hub manifest covers the
@@ -41,7 +41,7 @@ set of frames and emits them:
 ```yaml
 nodes:
   - id: dora-reachy2-camera
-    hub: dora-reachy2@^0.5
+    hub: dora-reachy2-camera@^0.5
     inputs:
       tick: dora/timer/millis/33
     outputs:

--- a/node-hub/dora-reachy2/README.md
+++ b/node-hub/dora-reachy2/README.md
@@ -1,37 +1,66 @@
 # dora-reachy2
 
-## Getting started
+Camera node for the Reachy 2 robot package — streams stereo teleop (left/right)
+and depth frames from a Reachy 2 over the network. This Hub manifest covers the
+**camera** node of the `dora-reachy2` package.
 
-- Install it with pip:
+## Behavior
 
-```bash
-pip install -e .
+On startup the node connects to the Reachy 2 robot at `ROBOT_IP`, retrying up to
+ten times until the teleop and depth cameras are reachable, and reads the depth
+camera intrinsics (focal length and resolution). On each `tick` it grabs a fresh
+set of frames and emits them:
+
+- the left teleop frame (`image_left`),
+- the right teleop frame (`image_right`),
+- the depth camera's color frame (`image_depth`), and
+- the depth frame in meters (`depth`), with camera intrinsics in its metadata.
+
+## Inputs
+
+- `tick`: trigger to capture and emit one set of camera frames (wire a timer).
+
+## Outputs
+
+- `image_left`: left teleop camera frame (bgr8), flattened Arrow array; metadata
+  carries width, height, encoding, primitive.
+- `image_right`: right teleop camera frame (bgr8), flattened Arrow array;
+  metadata carries width, height, encoding, primitive.
+- `image_depth`: depth camera color frame (bgr8), flattened Arrow array;
+  metadata carries width, height, encoding, primitive.
+- `depth`: depth frame in meters (float64), flattened Arrow array; metadata
+  carries width, height, focal, resolution, primitive.
+
+## Environment variables
+
+- `ROBOT_IP` (string, default `10.42.0.80`): IP address of the Reachy 2 robot to
+  connect to.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-reachy2-camera
+    hub: dora-reachy2@^0.5
+    inputs:
+      tick: dora/timer/millis/33
+    outputs:
+      - image_left
+      - image_right
+      - image_depth
+      - depth
+    env:
+      ROBOT_IP: 10.42.0.80
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-ruff check . --fix
+pip install .
 ```
 
-- Lint with ruff:
-
-```bash
-ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-reachy2's code are released under the MIT License
+> Note: the `dora-reachy2` package also ships arm, head, and mobile-base nodes
+> as separate console scripts (`dora-reachy2-left-arm`, `dora-reachy2-right-arm`,
+> `dora-reachy2-head`, `dora-reachy2-mobile-base`). Those nodes are **not**
+> covered by this single Hub manifest, which targets only the camera node
+> (`dora-reachy2-camera`).

--- a/node-hub/dora-reachy2/README.md
+++ b/node-hub/dora-reachy2/README.md
@@ -1,4 +1,4 @@
-# dora-reachy2-camera
+# dora-reachy2
 
 Camera node for the Reachy 2 robot package — streams stereo teleop (left/right)
 and depth frames from a Reachy 2 over the network. This Hub manifest covers the
@@ -41,7 +41,7 @@ set of frames and emits them:
 ```yaml
 nodes:
   - id: dora-reachy2-camera
-    hub: dora-reachy2-camera@^0.5
+    hub: dora-reachy2@^0.5
     inputs:
       tick: dora/timer/millis/33
     outputs:

--- a/node-hub/dora-reachy2/dora-node.yml
+++ b/node-hub/dora-reachy2/dora-node.yml
@@ -1,5 +1,5 @@
 apiVersion: 1
-name: dora-reachy2-camera
+name: dora-reachy2
 namespace: dora-rs
 description: >-
   Streams stereo teleop (left/right) and depth camera frames from a Reachy 2
@@ -31,7 +31,7 @@ env:
     description: IP address of the Reachy 2 robot to connect to.
 example: |
   - id: dora-reachy2-camera
-    hub: dora-reachy2-camera@^0.5
+    hub: dora-reachy2@^0.5
     inputs:
       tick: dora/timer/millis/33
     outputs:

--- a/node-hub/dora-reachy2/dora-node.yml
+++ b/node-hub/dora-reachy2/dora-node.yml
@@ -1,0 +1,41 @@
+apiVersion: 1
+name: dora-reachy2
+namespace: dora-rs
+description: >-
+  Streams stereo teleop (left/right) and depth camera frames from a Reachy 2
+  robot. This manifest covers the camera node of the dora-reachy2 package.
+categories: [sensor, robot]
+keywords: [reachy, reachy2, camera, stereo, depth, robot]
+runtime: python
+entrypoint: dora-reachy2-camera
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  tick:
+    required: true
+    description: Trigger to capture and emit one set of camera frames.
+outputs:
+  image_left:
+    description: Left teleop camera frame (bgr8) as a flattened Arrow array; metadata carries width, height, encoding, primitive.
+  image_right:
+    description: Right teleop camera frame (bgr8) as a flattened Arrow array; metadata carries width, height, encoding, primitive.
+  image_depth:
+    description: Depth camera color frame (bgr8) as a flattened Arrow array; metadata carries width, height, encoding, primitive.
+  depth:
+    description: Depth frame in meters (float64) as a flattened Arrow array; metadata carries width, height, focal, resolution, primitive.
+env:
+  ROBOT_IP:
+    type: string
+    default: "10.42.0.80"
+    description: IP address of the Reachy 2 robot to connect to.
+example: |
+  - id: dora-reachy2-camera
+    hub: dora-reachy2@^0.5
+    inputs:
+      tick: dora/timer/millis/33
+    outputs:
+      - image_left
+      - image_right
+      - image_depth
+      - depth

--- a/node-hub/dora-reachy2/dora-node.yml
+++ b/node-hub/dora-reachy2/dora-node.yml
@@ -1,5 +1,5 @@
 apiVersion: 1
-name: dora-reachy2
+name: dora-reachy2-camera
 namespace: dora-rs
 description: >-
   Streams stereo teleop (left/right) and depth camera frames from a Reachy 2
@@ -31,7 +31,7 @@ env:
     description: IP address of the Reachy 2 robot to connect to.
 example: |
   - id: dora-reachy2-camera
-    hub: dora-reachy2@^0.5
+    hub: dora-reachy2-camera@^0.5
     inputs:
       tick: dora/timer/millis/33
     outputs:

--- a/node-hub/dora-sam2/README.md
+++ b/node-hub/dora-sam2/README.md
@@ -1,40 +1,68 @@
 # dora-sam2
 
-> [!WARNING]  
-> SAM2 requires Nvidia GPU to be able to run.
+SAM2 image segmentation node. Given an image plus a box or point prompt, it runs
+the `facebook/sam2-hiera-large` predictor and emits the resulting boolean
+segmentation masks.
 
-## Getting started
+> [!WARNING]
+> SAM2 requires an Nvidia GPU to run — inference is wrapped in
+> `torch.autocast("cuda", ...)`.
 
-- Install it with pip:
+## Behavior
 
-```bash
-pip install -e .
+The node connects as a dora node and processes input events:
+
+- **`image`** inputs are decoded according to `metadata["encoding"]` (raw
+  `bgr8`/`rgb8`, or compressed `jpeg`/`jpg`/`jpe`/`bmp`/`webp`/`png`) using the
+  `width` and `height` metadata, converted to RGB, and cached as a PIL image
+  keyed by the input id. An unsupported encoding raises a `RuntimeError`. Image
+  events do not themselves produce output (the SAM2 tracking path is currently
+  disabled by an early `continue`).
+- **`boxes2d`** inputs run box-prompted prediction. The value is either a plain
+  xyxy Arrow array or a `StructArray` with `bbox` and `labels`; metadata must
+  carry `encoding: xyxy` and an `image_id` referencing a previously received
+  image input id. An empty value emits an empty `masks` array; otherwise the
+  predicted masks are emitted on `masks`.
+- **`points`** inputs run point-prompted prediction against the image named by
+  `metadata["image_id"]` (defaulting to the first cached image), then emit
+  `masks`. If no image has been received yet, the event is skipped.
+
+Input ids are matched by substring (`"image" in id`, `"boxes2d" in id`,
+`"points" in id`), so any id containing those tokens is accepted.
+
+## Inputs
+
+- `image`: image to segment. Metadata must carry `encoding`, `width`, `height`.
+- `boxes2d`: xyxy box prompts. Metadata must carry `encoding: xyxy` and
+  `image_id`. Triggers a `masks` output.
+- `points`: x,y point prompts. Metadata may carry `image_id`. Triggers a `masks`
+  output.
+
+## Outputs
+
+- `masks`: boolean segmentation masks flattened into an Arrow array. Metadata
+  carries `image_id`, `width`, `height`, and `primitive: masks`.
+
+## Environment variables
+
+None. The model (`facebook/sam2-hiera-large`) is hardcoded.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-sam2
+    hub: dora-sam2@^0.5
+    inputs:
+      image: camera/image
+      boxes2d: object-detector/boxes2d
+      points: object-detector/points
+    outputs:
+      - masks
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-ruff check . --fix
+pip install .
 ```
-
-- Lint with ruff:
-
-```bash
-ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-sam2's code are released under the MIT License

--- a/node-hub/dora-sam2/README.md
+++ b/node-hub/dora-sam2/README.md
@@ -28,7 +28,10 @@ The node connects as a dora node and processes input events:
   `masks`. If no image has been received yet, the event is skipped.
 
 Input ids are matched by substring (`"image" in id`, `"boxes2d" in id`,
-`"points" in id`), so any id containing those tokens is accepted.
+`"points" in id`). When run via `hub:`, wire each input on its declared id
+(`image`/`boxes2d`/`points`): the hub contract only permits declared input ids,
+even though the code would also accept any id containing those tokens (e.g.
+`camera_image`) when run via `path:`.
 
 ## Inputs
 
@@ -41,7 +44,8 @@ Input ids are matched by substring (`"image" in id`, `"boxes2d" in id`,
 ## Outputs
 
 - `masks`: boolean segmentation masks flattened into an Arrow array. Metadata
-  carries `image_id`, `width`, `height`, and `primitive: masks`.
+  carries `image_id`, `width`, `height` (and `primitive: masks` for masks
+  derived from a `boxes2d` request; the `points` path omits `primitive`).
 
 ## Environment variables
 

--- a/node-hub/dora-sam2/dora-node.yml
+++ b/node-hub/dora-sam2/dora-node.yml
@@ -43,6 +43,7 @@ env: {}
 
 example: |
   - id: dora-sam2
+    hub: dora-sam2@^0.5
     inputs:
       image: camera/image
       boxes2d: object-detector/boxes2d

--- a/node-hub/dora-sam2/dora-node.yml
+++ b/node-hub/dora-sam2/dora-node.yml
@@ -36,7 +36,8 @@ outputs:
   masks:
     description: >-
       Boolean segmentation masks, flattened (`masks.ravel()`) into an Arrow array.
-      Metadata carries `image_id`, `width`, `height`, and `primitive: masks`.
+      Metadata carries `image_id`, `width`, `height` (and `primitive: masks`
+      for masks derived from a `boxes2d` request; the `points` path omits it).
 
 env: {}
 

--- a/node-hub/dora-sam2/dora-node.yml
+++ b/node-hub/dora-sam2/dora-node.yml
@@ -1,0 +1,50 @@
+apiVersion: 1
+name: dora-sam2
+namespace: dora-rs
+description: >-
+  SAM2 image segmentation node. Given an image plus a box (boxes2d) or point
+  prompt, it runs the facebook/sam2-hiera-large predictor and emits the
+  resulting boolean segmentation masks as a flat Arrow array.
+categories: [ml-inference]
+keywords: [sam2, segmentation, masks, image, computer-vision]
+runtime: python
+entrypoint: dora-sam2
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    required: false
+    description: >-
+      Image to segment. Arrow array; metadata must carry `encoding`
+      (bgr8/rgb8 or jpeg/jpg/jpe/bmp/webp/png), `width`, and `height`. The frame
+      is cached under the input id so prompts can reference it via `image_id`.
+  boxes2d:
+    required: false
+    description: >-
+      Box prompts. Plain Arrow array of xyxy boxes (or a StructArray with `bbox`
+      and `labels`); metadata must carry `encoding: xyxy` and `image_id` matching
+      a previously received image input id. Triggers a `masks` output.
+  points:
+    required: false
+    description: >-
+      Point prompts. Arrow array of x,y pairs; metadata may carry `image_id`
+      (defaults to the first cached image). Triggers a `masks` output.
+
+outputs:
+  masks:
+    description: >-
+      Boolean segmentation masks, flattened (`masks.ravel()`) into an Arrow array.
+      Metadata carries `image_id`, `width`, `height`, and `primitive: masks`.
+
+env: {}
+
+example: |
+  - id: dora-sam2
+    inputs:
+      image: camera/image
+      boxes2d: object-detector/boxes2d
+      points: object-detector/points
+    outputs:
+      - masks

--- a/node-hub/dora-transformers/README.md
+++ b/node-hub/dora-transformers/README.md
@@ -1,168 +1,68 @@
 # dora-transformers
 
-A Dora node that provides access to Hugging Face transformer models for efficient text generation and chat completion.
+Generate text with a Hugging Face transformers causal-LM (text in → text out).
 
-## Features
+## Behavior
 
-- Multi-platform GPU acceleration support (CUDA, CPU, MPS)
-- Memory-efficient model loading with 8-bit quantization
-- Seamless integration with speech-to-text and text-to-speech pipelines
-- Configurable system prompts and activation words
-- Support for various transformer models
-- Conversation history management
-- Optimized for both small and large language models
+`dora-transformers` loads a Hugging Face `AutoModelForCausalLM` and
+`AutoTokenizer` for `MODEL_NAME` at startup, then runs as a dora node.
 
-## Getting Started
+For each input event it reads the first element of the Arrow array as a user
+message. If `ACTIVATION_WORDS` is set, the message is answered only when it
+contains at least one of those words; otherwise every input is answered. The
+message is fed through the tokenizer's chat template (optionally prefixed with
+`SYSTEM_PROMPT`), generated with `repetition_penalty=1.2` and up to
+`MAX_TOKENS` new tokens, decoded, and emitted on `text`.
 
-### Installation
+When `HISTORY` is true the assistant reply is appended to the running
+conversation so subsequent inputs see prior turns; otherwise each input is
+answered independently.
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
-```
+The node reads the value of **any** input id it receives, but a `hub:` contract
+must declare every wired input, so it declares one `text` input.
+
+## Inputs
+
+- `text`: prompt string. The first element of the Arrow array is read as the
+  user message.
+
+## Outputs
+
+- `text`: generated response as a single-element UTF-8 Arrow array.
+
+## Environment variables
+
+- `MODEL_NAME` (string, default `Qwen/Qwen2.5-0.5B-Instruct`): Hugging Face
+  model identifier or local path.
+- `SYSTEM_PROMPT` (string, default empty): optional system message prepended to
+  the conversation.
+- `MAX_TOKENS` (int, default `512`): maximum new tokens per response.
+- `DEVICE` (string, default `auto`): `device_map` passed to `from_pretrained`
+  (e.g. `auto`, `cpu`, `cuda`, `mps`).
+- `TORCH_DTYPE` (string, default `auto`): `torch_dtype` passed to
+  `from_pretrained` (e.g. `auto`, `float16`).
+- `HISTORY` (bool, default `false`): keep multi-turn history across inputs.
+- `ACTIVATION_WORDS` (string, default empty): space-separated trigger words;
+  when set, only inputs containing one respond.
 
 ## Usage
 
-Configure the node in your dataflow YAML file:
-
-```yaml
-- id: dora-transformers
-  build: pip install -e path/to/dora-transformers
-  path: dora-transformers
-  inputs:
-    text: source_node/text # Input text to generate response for
-  outputs:
-    - text # Generated response text
-  env:
-    MODEL_NAME: "Qwen/Qwen2.5-0.5B-Instruct" # Model from Hugging Face
-    SYSTEM_PROMPT: "You're a very succinct AI assistant with short answers."
-    ACTIVATION_WORDS: "what how who where you"
-    MAX_TOKENS: "128" # Reduced for concise responses
-    DEVICE: "cuda" # Use "cpu" for CPU, "cuda" for NVIDIA GPU, "mps" for Apple Silicon
-    ENABLE_MEMORY_EFFICIENT: "true" # Enable 8-bit quantization and memory optimizations
-    TORCH_DTYPE: "float16" # Use half precision for better memory efficiency
-```
-
-### Configuration Options
-
-- `MODEL_NAME`: Hugging Face model identifier (default: "Qwen/Qwen2.5-0.5B-Instruct")
-- `SYSTEM_PROMPT`: Customize the AI assistant's personality/behavior
-- `ACTIVATION_WORDS`: Space-separated list of words that trigger model response
-- `MAX_TOKENS`: Maximum number of tokens to generate (default: 128)
-- `DEVICE`: Computation device to use (default: "cpu")
-- `ENABLE_MEMORY_EFFICIENT`: Enable memory optimizations (default: "true")
-- `TORCH_DTYPE`: Model precision type (default: "auto")
-
-### Memory Management
-
-The node includes several memory optimization features:
-
-- 8-bit quantization for CUDA devices
-- Automatic CUDA cache clearing
-- Memory-efficient model loading
-- Half-precision support
-
-## Example: Voice Assistant Pipeline
-
-Create a conversational AI pipeline that:
-
-1. Captures audio from microphone
-2. Converts speech to text
-3. Generates AI responses using transformers
-4. Converts responses back to speech
-
 ```yaml
 nodes:
-  - id: dora-microphone
-    build: pip install -e ../../dora-microphone
-    path: dora-microphone
-    inputs:
-      tick: dora/timer/millis/2000
-    outputs:
-      - audio
-
-  - id: dora-vad
-    build: pip install -e ../../dora-vad
-    path: dora-vad
-    inputs:
-      audio: dora-microphone/audio
-    outputs:
-      - audio
-      - timestamp_start
-
-  - id: dora-distil-whisper
-    build: pip install -e ../../dora-distil-whisper
-    path: dora-distil-whisper
-    inputs:
-      input: dora-vad/audio
-    outputs:
-      - text
-    env:
-      TARGET_LANGUAGE: english
-
   - id: dora-transformers
-    build: pip install -e ../../dora-transformers
-    path: dora-transformers
+    hub: dora-transformers
     inputs:
-      text: dora-distil-whisper/text
+      text: source-node/text
     outputs:
       - text
     env:
       MODEL_NAME: "Qwen/Qwen2.5-0.5B-Instruct"
-      SYSTEM_PROMPT: "You are an AI assistant that gives extremely concise responses, never more than one or two sentences. Always be direct and to the point."
-      ACTIVATION_WORDS: "what how who where you"
+      SYSTEM_PROMPT: "You are a succinct AI assistant with short answers."
       MAX_TOKENS: "128"
-      DEVICE: "cuda"
-      ENABLE_MEMORY_EFFICIENT: "true"
-      TORCH_DTYPE: "float16"
-
-  - id: dora-kokoro-tts
-    build: pip install -e ../../dora-kokoro-tts
-    path: dora-kokoro-tts
-    inputs:
-      text: dora-transformers/text
-    outputs:
-      - audio
 ```
 
-### Running the Example
+## Build
 
 ```bash
-dora build test.yml
-dora run test.yml
+pip install .
 ```
-
-### Troubleshooting
-
-If you encounter CUDA out of memory errors:
-
-1. Set `DEVICE: "cpu"` for CPU-only inference
-2. Enable memory optimizations with `ENABLE_MEMORY_EFFICIENT: "true"`
-3. Use a smaller model or reduce `MAX_TOKENS`
-4. Set `TORCH_DTYPE: "float16"` for reduced memory usage
-
-## Contribution Guide
-
-Format with [ruff](https://docs.astral.sh/ruff/):
-
-```bash
-uv pip install ruff
-uv run ruff check . --fix
-```
-
-Lint with ruff:
-
-```bash
-uv run ruff check .
-```
-
-Test with [pytest](https://github.com/pytest-dev/pytest):
-
-```bash
-uv pip install pytest
-uv run pytest . # Test
-```
-
-## License
-
-dora-transformers is released under the MIT License

--- a/node-hub/dora-transformers/dora-node.yml
+++ b/node-hub/dora-transformers/dora-node.yml
@@ -1,0 +1,74 @@
+apiVersion: 1
+name: dora-transformers
+namespace: dora-rs
+description: >-
+  Generate text with a Hugging Face transformers causal-LM. Receives an input
+  string, applies the tokenizer chat template, generates a reply, and emits the
+  decoded text. Supports an optional system prompt, activation-word gating, and
+  multi-turn history.
+categories: [llm, ml-inference]
+keywords: [transformers, huggingface, text-generation, llm, chat]
+runtime: python
+entrypoint: dora-transformers
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  text:
+    required: false
+    description: >-
+      Prompt string to generate a response for. The first element of the Arrow
+      array is read as the user message.
+
+outputs:
+  text:
+    description: Generated response text as a single-element UTF-8 Arrow array.
+
+env:
+  MODEL_NAME:
+    type: string
+    default: "Qwen/Qwen2.5-0.5B-Instruct"
+    description: Hugging Face model identifier or local path to load.
+  SYSTEM_PROMPT:
+    type: string
+    default: ""
+    description: >-
+      Optional system message prepended to the conversation. Empty disables it.
+  MAX_TOKENS:
+    type: int
+    default: 512
+    description: Maximum number of new tokens to generate per response.
+  DEVICE:
+    type: string
+    default: "auto"
+    description: >-
+      device_map passed to from_pretrained (e.g. "auto", "cpu", "cuda", "mps").
+  TORCH_DTYPE:
+    type: string
+    default: "auto"
+    description: torch_dtype passed to from_pretrained (e.g. "auto", "float16").
+  HISTORY:
+    type: bool
+    default: false
+    description: >-
+      When true, keep multi-turn conversation history across inputs; otherwise
+      each input is answered independently.
+  ACTIVATION_WORDS:
+    type: string
+    default: ""
+    description: >-
+      Space-separated trigger words. When set, a response is only generated if
+      the input contains at least one of them. Empty responds to every input.
+
+example: |
+  - id: dora-transformers
+    hub: dora-transformers
+    inputs:
+      text: source-node/text
+    outputs:
+      - text
+    env:
+      MODEL_NAME: "Qwen/Qwen2.5-0.5B-Instruct"
+      SYSTEM_PROMPT: "You are a succinct AI assistant with short answers."
+      MAX_TOKENS: "128"

--- a/node-hub/dora-transformers/dora_transformers/main.py
+++ b/node-hub/dora-transformers/dora_transformers/main.py
@@ -76,12 +76,13 @@ def generate_response(model, tokenizer, text: str, history) -> tuple[str, list]:
 
 def main():
     """TODO: Add docstring."""
+    # Connect to the dataflow first so a misconfigured run fails fast (raising a
+    # dora RuntimeError) before the slow, network-bound model download.
+    node = Node()
+
     # Initialize model and conversation history
     model, tokenizer = load_model()
-    # Initialize history with system prompt
-
     history = [{"role": "system", "content": SYSTEM_PROMPT}] if SYSTEM_PROMPT else []
-    node = Node()
 
     for event in node:
         if event["type"] == "INPUT":

--- a/node-hub/dora-vggt/README.md
+++ b/node-hub/dora-vggt/README.md
@@ -1,40 +1,67 @@
 # dora-vggt
 
-## Getting started
+Runs the [VGGT](https://github.com/facebookresearch/vggt) (Visual Geometry
+Grounded Transformer) `facebook/VGGT-1B` model on incoming images to predict
+depth maps and camera intrinsics.
 
-- Install it with uv:
+## Behavior
 
-```bash
-uv venv -p 3.11 --seed
-uv pip install -e .
+On each image input, the node decodes the frame (`bgr8`, `rgb8`, or encoded
+`jpeg`/`jpg`/`jpe`/`bmp`/`webp`/`png`), buffers up to `VGGT_NUM_IMAGES` recent
+frames, and runs them through VGGT. It predicts camera poses (extrinsic +
+intrinsic, OpenCV convention) and a depth map. Low-confidence depth pixels
+(confidence < 1.0) are zeroed.
+
+It then emits two outputs: a depth map (scaled by `SCALE_FACTOR`, encoded per
+`DEPTH_ENCODING`) and the preprocessed RGB image. Both carry the predicted focal
+length and principal point in metadata. If CUDA is available the model runs on
+GPU, otherwise CPU. The `facebook/VGGT-1B` weights download automatically on
+first run.
+
+The node keys off the substring `image` in the input id: the depth output id is
+that id with `image` replaced by `depth`, and the RGB output reuses the input id
+unchanged.
+
+## Inputs
+
+- `image`: an image whose id contains `image`. Value is a flat pixel buffer (or
+  encoded bytes); metadata must provide `encoding`, `width`, and `height`.
+
+## Outputs
+
+- `depth`: predicted depth map (input id with `image` -> `depth`). Flat array;
+  metadata has `width`, `height`, `encoding` (`float64` raw or `mono16` scaled
+  ×1000), `focal` `[fx, fy]`, `resolution` `[cx, cy]` (principal point).
+- `image`: preprocessed RGB image echoed under the original input id. Flat
+  `uint8` buffer; metadata has `encoding: rgb8`, `width`, `height`, `focal`,
+  `resolution`.
+
+## Environment variables
+
+- `SCALE_FACTOR` (float, default `1.0`): multiplier applied to the depth map.
+- `VGGT_NUM_IMAGES` (int, default `2`): number of recent images buffered and fed
+  to the model together.
+- `DEPTH_ENCODING` (string, default `float64`): `float64` emits raw depth;
+  `mono16` multiplies by 1000 and casts to `uint16`.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-vggt
+    hub: dora-vggt@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - depth
+      - image
+    env:
+      VGGT_NUM_IMAGES: 2
+      DEPTH_ENCODING: float64
 ```
 
-## Contribution Guide
-
-- Format with [ruff](https://docs.astral.sh/ruff/):
+## Build
 
 ```bash
-uv pip install ruff
-uv run ruff check . --fix
+pip install .
 ```
-
-- Lint with ruff:
-
-```bash
-uv run ruff check .
-```
-
-- Test with [pytest](https://github.com/pytest-dev/pytest)
-
-```bash
-uv pip install pytest
-uv run pytest . # Test
-```
-
-## YAML Specification
-
-## Examples
-
-## License
-
-dora-vggt's code are released under the MIT License

--- a/node-hub/dora-vggt/README.md
+++ b/node-hub/dora-vggt/README.md
@@ -20,7 +20,10 @@ first run.
 
 The node keys off the substring `image` in the input id: the depth output id is
 that id with `image` replaced by `depth`, and the RGB output reuses the input id
-unchanged.
+unchanged. When run via `hub:`, wire the input on the declared id `image` (so the
+outputs are exactly the declared `depth` and `image`); the hub contract permits
+only declared input ids, even though `path:` dataflows may use any id containing
+`image`.
 
 ## Inputs
 

--- a/node-hub/dora-vggt/dora-node.yml
+++ b/node-hub/dora-vggt/dora-node.yml
@@ -1,0 +1,68 @@
+apiVersion: 1
+name: dora-vggt
+namespace: dora-rs
+description: >-
+  VGGT (Visual Geometry Grounded Transformer) node — runs the facebook/VGGT-1B
+  model on incoming images to predict per-image depth maps plus camera focal and
+  principal-point parameters, and echoes back the preprocessed RGB image.
+categories: [ml-inference]
+keywords:
+  - vggt
+  - depth
+  - 3d-reconstruction
+  - camera-pose
+  - geometry
+runtime: python
+entrypoint: dora-vggt
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    description: >-
+      Input image whose id contains the substring "image". The value is a flat
+      pixel buffer (or encoded bytes) with metadata fields encoding
+      (bgr8/rgb8/jpeg/jpg/jpe/bmp/webp/png), width and height. Images are
+      buffered up to VGGT_NUM_IMAGES frames and fed to the model together.
+
+outputs:
+  depth:
+    description: >-
+      Predicted depth map for the latest image (input id with "image" replaced
+      by "depth"). Flat array; metadata carries width, height, encoding
+      (DEPTH_ENCODING: float64 raw, or mono16 scaled by 1000), focal [fx, fy]
+      and resolution [cx, cy] (principal point).
+  image:
+    description: >-
+      The preprocessed RGB image echoed back under the original input id, as a
+      flat uint8 buffer with metadata encoding rgb8, width, height, focal and
+      resolution (principal point).
+
+env:
+  SCALE_FACTOR:
+    type: float
+    default: 1.0
+    description: Multiplier applied to the predicted depth map before output.
+  VGGT_NUM_IMAGES:
+    type: int
+    default: 2
+    description: Number of recent images buffered and fed to the model together.
+  DEPTH_ENCODING:
+    type: string
+    default: float64
+    description: >-
+      Depth output encoding. "float64" emits raw depth; "mono16" multiplies by
+      1000 and casts to uint16.
+
+example: |
+  - id: dora-vggt
+    hub: dora-vggt@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - depth
+      - image
+    env:
+      VGGT_NUM_IMAGES: 2
+      DEPTH_ENCODING: float64

--- a/node-hub/lerobot-dashboard/README.md
+++ b/node-hub/lerobot-dashboard/README.md
@@ -1,40 +1,71 @@
-## LeRobot Record Interface
+# lerobot-dashboard
 
-Simple Interface that uses Pygame to display images and texts. It also manages keyboard events.
-This simple interface can only display two images of the same size side by side and a text in the middle bottom of the
-screen.
+Pygame dashboard for LeRobot dataset recording — displays two images side by side
+plus a status text, and turns keyboard events into episode-recording control
+outputs.
 
-## YAML Configuration
+## Behavior
 
-````YAML
-nodes:
-  - id: lerobot_record
-    path: record.py # modify this to the relative path from the graph file to the client script
-    inputs:
-      tick: dora/timer/millis/16 # update the interface every 16ms (= 60fps)
+`lerobot-dashboard` opens a Pygame window and connects as a dora node. On each
+`tick` it redraws the window (left image, right image, and a status text at the
+bottom center) and processes pending keyboard events:
 
-      # image_left: some image from other node 
-      # image_right: some image from other node
-    outputs:
-      - text
-      - episode
-      - failed
-      - end # end signal that can be sent to other nodes (sent when the window is closed)
+- **Space**: toggle recording. When starting, it emits `episode` with the current
+  episode index; when stopping, it emits `episode` with `-1` and advances the
+  episode index.
+- **Return**: mark an episode as failed. While recording, it emits `failed` with
+  the current episode index, advances the index, and emits `episode` with `-1`.
+  When idle (and at least one episode exists), it emits `failed` with the previous
+  episode index.
+- **Window close (QUIT)**: ends the loop.
 
-    env:
-      WINDOW_WIDTH: 1280 # window width (default is 640) 
-      WINDOW_HEIGHT: 1080 # window height (default is 480)
-````
+The status text is rendered locally (e.g. "Recording episode N"); it is not
+emitted as an output. Each `tick` is echoed back on the `tick` output. When the
+window closes, an empty `end` output is sent.
 
 ## Inputs
 
-## Outputs:
+- `image_left`: image for the left half of the window (dora Arrow image struct
+  with `width`/`height`/`channels`/`data`, interpreted as BGR).
+- `image_right`: image for the right half of the window (same format).
+- `tick`: refresh trigger; drives redraw and keyboard handling.
 
-- `text` : Array containing 1 element, the text in Arrow format.
-- `episode` : Array containing 1 element, the episode number in Arrow format (or -1, marks episode end).
-- `failed` : Array containing 1 element, the episode number failed in Arrow format.
-- `end` : Array containing 1 empty element, indicates the end of recording to the dataflow.
+## Outputs
 
-## License
+- `tick`: echoed once per received tick (empty array), forwarding the tick's
+  metadata.
+- `episode`: single-element array — the episode index when recording starts, or
+  `-1` when recording stops.
+- `failed`: single-element array — the index of the episode marked as failed.
+- `end`: single empty-element array, emitted when the window is closed.
 
-This library is licensed under the [Apache License 2.0](../../LICENSE).
+## Environment variables
+
+- `WINDOW_WIDTH` (int, default `640`): window width in pixels.
+- `WINDOW_HEIGHT` (int, default `480`): window height in pixels.
+
+## Usage
+
+```yaml
+nodes:
+  - id: lerobot-dashboard
+    hub: lerobot-dashboard@^0.5
+    inputs:
+      tick: dora/timer/millis/16
+      image_left: camera-left/image
+      image_right: camera-right/image
+    outputs:
+      - tick
+      - episode
+      - failed
+      - end
+    env:
+      WINDOW_WIDTH: 1280
+      WINDOW_HEIGHT: 1080
+```
+
+## Build
+
+```bash
+pip install .
+```

--- a/node-hub/lerobot-dashboard/dora-node.yml
+++ b/node-hub/lerobot-dashboard/dora-node.yml
@@ -1,0 +1,62 @@
+apiVersion: 1
+name: lerobot-dashboard
+namespace: dora-rs
+description: Pygame dashboard for LeRobot dataset recording — displays two images side by side plus a status text, and turns keyboard events into episode-recording control outputs.
+categories:
+  - visualization
+  - recorder
+keywords:
+  - lerobot
+  - pygame
+  - dashboard
+  - keyboard
+  - recording
+runtime: python
+entrypoint: lerobot-dashboard
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image_left:
+    description: Image shown in the left half of the window (dora Arrow image struct with width/height/channels/data, BGR).
+  image_right:
+    description: Image shown in the right half of the window (dora Arrow image struct with width/height/channels/data, BGR).
+  tick:
+    description: Refresh trigger; on each tick the window is redrawn and pending keyboard events are processed.
+
+outputs:
+  tick:
+    description: Echoed once per received tick (empty array), forwarding the tick's metadata downstream.
+  episode:
+    description: Single-element array with the episode index when recording starts, or -1 when recording stops.
+  failed:
+    description: Single-element array with the index of the episode marked as failed.
+  end:
+    description: Single empty-element array emitted when the window is closed, signalling end of recording.
+
+env:
+  WINDOW_WIDTH:
+    type: int
+    default: 640
+    description: Window width in pixels.
+  WINDOW_HEIGHT:
+    type: int
+    default: 480
+    description: Window height in pixels.
+
+example: |
+  - id: lerobot-dashboard
+    hub: lerobot-dashboard@^0.5
+    inputs:
+      tick: dora/timer/millis/16
+      image_left: camera-left/image
+      image_right: camera-right/image
+    outputs:
+      - tick
+      - episode
+      - failed
+      - end
+    env:
+      WINDOW_WIDTH: 1280
+      WINDOW_HEIGHT: 1080

--- a/node-hub/lerobot-dashboard/lerobot_dashboard/main.py
+++ b/node-hub/lerobot-dashboard/lerobot_dashboard/main.py
@@ -54,7 +54,7 @@ def main():
 
     pygame.display.set_caption("Pygame minimalistic interface")
 
-    node = Node(args.name)
+    node = Node()
 
     episode_index = 1
     recording = False

--- a/node-hub/llama-factory-recorder/README.md
+++ b/node-hub/llama-factory-recorder/README.md
@@ -13,7 +13,7 @@ The node connects as a dora node and buffers inputs to assemble training samples
   `jpeg`) and buffered as a frame.
 - A non-empty `text` input overrides the prompt question (default
   `DEFAULT_QUESTION`) for the next sample.
-- A `ground_truth` input triggers a write: the buffered frames are saved as PNGs
+- A `ground_truth` input triggers a write: the buffered frames are saved as PNG files
   and a ShareGPT message pair (`user` prompt with one `<image>` token per frame +
   `assistant` ground-truth) is appended to the dataset JSON. If no frames are
   buffered yet, the `ground_truth` is ignored.

--- a/node-hub/llama-factory-recorder/README.md
+++ b/node-hub/llama-factory-recorder/README.md
@@ -1,50 +1,76 @@
-# Dora Llama factory recorder
+# llama-factory-recorder
 
-Experimental node for recording for training llama based model.
+Records dataflow image and ground-truth inputs into [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory)
+training data: it writes ShareGPT-format JSON samples and saves the corresponding
+image frames as PNG files, ready for fine-tuning a vision-language model.
 
-## Get started
+## Behavior
 
-- Git clone llama-factory:
+The node connects as a dora node and buffers inputs to assemble training samples:
 
-```bash
-git clone https://github.com/hiyouga/LLaMA-Factory --depth 1 $HOME
-```
+- Any input whose id contains the substring `image` (e.g. `image_right`) is
+  decoded from its `encoding`/`width`/`height` metadata (`bgr8`, `rgb8` or
+  `jpeg`) and buffered as a frame.
+- A non-empty `text` input overrides the prompt question (default
+  `DEFAULT_QUESTION`) for the next sample.
+- A `ground_truth` input triggers a write: the buffered frames are saved as PNGs
+  and a ShareGPT message pair (`user` prompt with one `<image>` token per frame +
+  `assistant` ground-truth) is appended to the dataset JSON. If no frames are
+  buffered yet, the `ground_truth` is ignored.
 
-- Replace your AI model node with llama-factory-recorder node.
+On startup it requires `LLAMA_FACTORY_ROOT_PATH` and writes the dataset JSON,
+`dataset_info.json` and image folders under `<LLAMA_FACTORY_ROOT_PATH>/data`. If
+the dataset name already exists, an incremental suffix is appended so existing
+data is not overwritten.
 
-Example:
+## Inputs
+
+- `image`: an image frame to record. Any input id containing `image` is treated
+  as an image; metadata must carry `encoding` (`bgr8`/`rgb8`/`jpeg`), `width` and
+  `height`.
+- `text`: optional prompt text; a non-empty value overrides `DEFAULT_QUESTION`.
+- `ground_truth`: the assistant answer; receiving it writes a sample.
+
+The node matches image inputs by substring, so multiple image streams can be
+wired under distinct ids (each must contain `image`); the contract declares one
+generic `image` input. To record arbitrary image-input names, run it directly via
+`path:` (where the contract isn't enforced).
+
+## Outputs
+
+- `text`: echoes the recorded `ground_truth` text after a sample is written.
+
+## Environment variables
+
+- `DEFAULT_QUESTION` (string, default `Describe this image`): default user prompt
+  used when no `text` input overrides it.
+- `LLAMA_FACTORY_ROOT_PATH` (string, required): path to the LLaMA-Factory
+  checkout. Output is written under `<path>/data`.
+- `ENTRY_NAME` (string, default `dora_demo`): dataset name used for the JSON
+  file, image subfolder and `dataset_info.json` key.
+
+## Usage
 
 ```yaml
-- id: dora-qwenvl-recorder
-  build: pip install -e ../../llama-factory-recorder
-  path: llama-factory-recorder
-  inputs:
-    image_right: reachy/image_right
-    ground_truth: key-interpolation/text
-  outputs:
-    - text
-  env:
-    DEFAULT_QUESTION: Respond to people. # Prompt to use
-    LLAMA_FACTORY_ROOT_PATH: $HOME/LLaMA-Factory # path to llama factory
+nodes:
+  - id: llama-factory-recorder
+    hub: llama-factory-recorder@^0.5
+    inputs:
+      image: camera/image
+      text: planner/text
+      ground_truth: planner/ground_truth
+    outputs:
+      - text
+    env:
+      DEFAULT_QUESTION: Describe this image
+      LLAMA_FACTORY_ROOT_PATH: /path/to/LLaMA-Factory
 ```
 
-- Run your dataflow and at the end of the run you will find your data within the llama factory folder.
-- Modify `llama-factory/examples/train_lora/qwen2vl_lora_sft.yaml` so that the dataset is the one you want to use,
+After the run, the recorded dataset is in `<LLAMA_FACTORY_ROOT_PATH>/data`; point
+your LLaMA-Factory training config's `dataset:` at the `ENTRY_NAME` you used.
 
-```yaml,diff
-- dataset: mllm_demo,identity  # video: mllm_video_demo
-+ dataset: dora_demo_1,identity`
-```
-
-- You can also choose the 2B model instead of the 7B model with
-
-```yaml,diff
-- model_name_or_path: Qwen/Qwen2-VL-7B-Instruct
-+ model_name_or_path: Qwen/Qwen2.5-VL-3B-Instruct
-```
-
-- Then
+## Build
 
 ```bash
-llamafactory-cli train examples/train_lora/qwen2vl_lora_sft.yaml
+pip install .
 ```

--- a/node-hub/llama-factory-recorder/dora-node.yml
+++ b/node-hub/llama-factory-recorder/dora-node.yml
@@ -1,0 +1,62 @@
+apiVersion: 1
+name: llama-factory-recorder
+namespace: dora-rs
+description: Records dataflow image + ground-truth inputs into LLaMA-Factory ShareGPT training data (JSON + saved PNG frames).
+categories: [recorder]
+keywords: [llama-factory, recorder, training-data, vlm, sharegpt, dataset]
+runtime: python
+entrypoint: llama-factory-recorder
+build: pip install .
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    description: >-
+      An image frame to record. Any input whose id contains the substring
+      "image" is treated as an image (e.g. image_right). Metadata must carry
+      encoding (bgr8/rgb8/jpeg), width and height. Frames are buffered until a
+      ground_truth arrives.
+  text:
+    description: >-
+      Optional prompt/question text. A non-empty value overrides DEFAULT_QUESTION
+      for the next recorded sample.
+  ground_truth:
+    description: >-
+      The assistant answer text. Receiving it writes a ShareGPT sample (the
+      buffered images + question/answer messages) to the dataset and saves the
+      images as PNG files. Ignored if no image frames are buffered yet.
+
+outputs:
+  text:
+    description: Echoes the recorded ground_truth text after writing the sample.
+
+env:
+  DEFAULT_QUESTION:
+    type: string
+    default: Describe this image
+    description: Default user prompt used when no text input overrides it.
+  LLAMA_FACTORY_ROOT_PATH:
+    type: string
+    description: >-
+      Required. Path to the LLaMA-Factory checkout. Recorded JSON, dataset_info.json
+      and image folders are written under "<path>/data".
+  ENTRY_NAME:
+    type: string
+    default: dora_demo
+    description: >-
+      Dataset name. Used for the JSON file, image subfolder and dataset_info.json
+      key; an incremental suffix is appended if it already exists.
+
+example: |
+  - id: llama-factory-recorder
+    hub: llama-factory-recorder@^0.5
+    inputs:
+      image: camera/image
+      text: planner/text
+      ground_truth: planner/ground_truth
+    outputs:
+      - text
+    env:
+      DEFAULT_QUESTION: Describe this image
+      LLAMA_FACTORY_ROOT_PATH: /path/to/LLaMA-Factory


### PR DESCRIPTION
Source-side Hub migration batch 5 — the remaining **Python** nodes (off main). All 13 pass `dora validate --node-manifest`.

cotracker, dataset-record, mujoco, mujoco-husky, policy-inference, qwen2-5-vl, reachy2 (camera), sam2, transformers, vggt, llama-factory-recorder, lerobot-dashboard, llama-cpp-python.

**Doc drift corrected to match code:** dora-transformers (phantom 8-bit/bitsandbytes/ENABLE_MEMORY_EFFICIENT + wrong defaults), policy-inference (phantom `*_RESOLUTION` env), lerobot-dashboard (phantom `text` output), mujoco (invalid `go2` default).

**Flagged, not fixed** (not one-liners): sam2 dead image-tracking branch (`TODO: Fix`); CUDA-only autocast in sam2/qwen2-5-vl; policy-inference unreachable MODEL_PATH check; latent KeyErrors on missing metadata.

**Multi-node packages:** `dora-reachy2` ships 5 console scripts — only the camera node is migrated; arms/head/base need their own dirs/manifests (same for `dora-reachy1` in #80).

After this: all Python nodes are migrated. Remaining = Rust + hybrid (batch 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)