### PR TITLE
feat(node-hub): migrate batch 6 (13 Rust nodes) to Hub manifest format

### DIFF
--- a/node-hub/dora-dav1d/README.md
+++ b/node-hub/dora-dav1d/README.md
@@ -1,0 +1,63 @@
+# dora-dav1d
+
+AV1 video decoder using the [dav1d](https://crates.io/crates/dav1d) decoder.
+It takes encoded AV1 byte streams in and emits raw decoded image frames out.
+
+## Behavior
+
+`dora-dav1d` connects as a dora node and feeds every input event into a dav1d
+decoder. For each input it:
+
+- Accepts only UInt8 Arrow arrays; other data types are ignored with a warning.
+- Requires the input's `encoding` parameter to be `av1` (defaults to `av1` when
+  absent); any other encoding is skipped with a warning.
+- Sends the bytes to the decoder and, when a picture is available, converts it
+  based on its pixel layout:
+  - **I420 (color)** — controlled by the `ENCODING` environment variable:
+    `bgr8` produces interleaved BGR; `yuv420` produces planar Y/U/V concatenated
+    plus `width` and `height` parameters.
+  - **I400 (mono)** — emits `mono8` for 8-bit pictures or `mono16` for 10-/12-bit
+    pictures.
+- Unsupported pixel layouts, bit depths, or output encodings are skipped with a
+  warning.
+
+The decoded frame is emitted under the **same id** as the received input.
+
+## Inputs
+
+- `tick`: encoded AV1 data as a UInt8 Arrow array, with an `encoding=av1`
+  parameter. The node echoes the output under this same id, so the input id
+  determines the output id.
+
+## Outputs
+
+- `tick`: the decoded image frame as an Arrow array, emitted under the same id
+  as the input. Metadata carries `encoding` (`bgr8`, `yuv420`, `mono8`, or
+  `mono16`), `primitive: image`, and `width`/`height` for `yuv420`.
+
+## Environment variables
+
+- `ENCODING` (default `bgr8`): output pixel encoding for I420 color pictures.
+  `bgr8` converts to interleaved BGR; `yuv420` emits planar Y/U/V with `width`
+  and `height` parameters. Mono pictures ignore this setting.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-dav1d
+    build: cargo build --release --target-dir target
+    path: target/release/dora-dav1d
+    inputs:
+      tick: encoder/encoded
+    outputs:
+      - tick
+    env:
+      ENCODING: bgr8
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-dav1d/dora-node.yml
+++ b/node-hub/dora-dav1d/dora-node.yml
@@ -1,0 +1,49 @@
+apiVersion: 1
+name: dora-dav1d
+namespace: dora-rs
+description: AV1 video decoder using dav1d — decodes encoded AV1 byte streams into raw image frames (BGR8, YUV420, or mono).
+categories: [transform]
+keywords: [av1, decoder, video, dav1d, image]
+runtime: rust
+entrypoint: target/release/dora-dav1d
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  tick:
+    description: |
+      Encoded AV1 data as a UInt8 Arrow array. The input must carry an
+      `encoding` parameter equal to `av1`; other encodings are skipped with a
+      warning. Non-UInt8 data types are ignored. The output is emitted under
+      the same id as this input.
+
+outputs:
+  tick:
+    description: |
+      Decoded image frame as an Arrow array, emitted under the same id as the
+      received input. Carries `encoding` (`bgr8`, `yuv420`, `mono8`, or
+      `mono16` depending on the decoded picture and the ENCODING setting),
+      `primitive: image`, and — for `yuv420` — `width` and `height`
+      parameters.
+
+env:
+  ENCODING:
+    type: string
+    default: bgr8
+    description: |
+      Output pixel encoding for I420 (color) pictures. `bgr8` converts to
+      interleaved BGR; `yuv420` emits planar Y/U/V concatenated with width and
+      height parameters. Other values are skipped with a warning. Mono (I400)
+      pictures ignore this and emit `mono8` or `mono16` based on bit depth.
+
+example: |
+  - id: dora-dav1d
+    build: cargo build --release --target-dir target
+    path: target/release/dora-dav1d
+    inputs:
+      tick: encoder/encoded
+    outputs:
+      - tick
+    env:
+      ENCODING: bgr8

--- a/node-hub/dora-kit-car/README.md
+++ b/node-hub/dora-kit-car/README.md
@@ -1,55 +1,61 @@
-# dora-kit-car control
+# dora-kit-car
 
-## Introduce
+Differential-drive ("kit car") mobile-robot controller. Receives velocity
+commands and drives the robot forward/backward and turns it left/right by
+writing chassis speed frames to a serial port.
 
-Dora Kit Car is a DORA node for controlling a differential-drive mobile robot to move forward/backward and turn left/right. Developed in Rust with Python API support.
+## Behavior
 
-## Highlights
+`dora-kit-car` connects as a dora node and opens the serial port named by the
+`SERIAL_PORT` environment variable at 115200 baud (8N1, no flow control). For
+every input event it receives, it interprets the payload as an Apache Arrow
+`Float64Array`. When the array has exactly 6 elements it reads them as a ROS
+`geometry_msgs/Twist` vector `[x, y, z, rx, ry, rz]`, takes the linear `x`
+(index 0) and angular `rz` (index 5), encodes them into a chassis command frame,
+and writes that frame to the serial port. Arrays of any other length are
+ignored.
 
-- Compatible with the ROS geometry_msgs/Twist.msg format, utilizing only:
-- linear.x (positive: forward movement, negative: backward movement)
-- angular.z (positive: left turn, negative: right turn)
+The node listens on **any** input id (it does not match on a specific name), so
+the wired input can be called anything; the Hub contract declares it as `tick`.
+It produces no outputs.
 
-## Raw Message Definition
+## Inputs
 
-Accepts an array of six f64's
+- `tick`: velocity command as a `Float64Array` of length 6 in
+  `geometry_msgs/Twist` order `[x, y, z, rx, ry, rz]`. Only `x` (forward/back)
+  and `rz` (turn) are used.
 
-- six f64 array [x, y, z, rx, ry, rz] only used x, rz
+## Outputs
 
-see [https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html](https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html)
+None — it is an actuator sink.
 
-## Environment
+## Environment variables
 
-Adds an environment variable `SERIAL_PORT` to specify the serial port for the car device, with `/dev/ttyUSB0` as the default value
+- `SERIAL_PORT` (string, default `/dev/ttyUSB0`): serial port device the car
+  chassis is connected to.
 
-## Demo Video
-
-[![Dora Kit Car Video](https://yt3.ggpht.com/92FGXQL59VsiXim13EJQek4IB7CRI-9SjmW3LhH8PFY16oBXqKUvkKhg5UdzLiGCOmoSuTvdpQxIuw=s640-rw-nd-v1)](https://youtu.be/B7zGHtRUZSo)
-
-## Getting Started
+## Usage
 
 ```yaml
 nodes:
-  - id: keyboard-listener # Run on car
+  - id: keyboard-listener
     build: pip install dora-keyboard
     path: dora-keyboard
     inputs:
       tick: dora/timer/millis/10
     outputs:
-      - twist # for example [2.0,0.0,0.0,0.0,0.0,1.0]
+      - twist # e.g. [2.0, 0.0, 0.0, 0.0, 0.0, 1.0]
 
-  - id: car
-    build: pip install dora-kit-car
-    path: dora-kit-car
+  - id: dora-kit-car
+    hub: dora-kit-car@^0.3
     inputs:
-      keyboard: keyboard-listener/twist
+      tick: keyboard-listener/twist
     env:
       SERIAL_PORT: /dev/ttyUSB0
-
 ```
 
-## License
+## Build
 
-The MIT License (MIT)
-
-Copyright (c) 2024-present, Leon
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-kit-car/dora-node.yml
+++ b/node-hub/dora-kit-car/dora-node.yml
@@ -1,0 +1,39 @@
+apiVersion: 1
+name: dora-kit-car
+namespace: dora-rs
+description: >-
+  Differential-drive ("kit car") mobile-robot controller. Receives velocity
+  commands as a 6-element Float64 array ([x, y, z, rx, ry, rz], ROS
+  geometry_msgs/Twist layout — only linear x and angular z are used) and writes
+  the corresponding chassis speed frame to a serial port at 115200 baud.
+categories: [actuator, robot]
+keywords: [differential-drive, mobile-robot, serial, twist, velocity, chassis]
+runtime: rust
+entrypoint: target/release/dora-kit-car
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  tick:
+    description: >-
+      Velocity command as a Float64 array of length 6 in ROS
+      geometry_msgs/Twist order [x, y, z, rx, ry, rz]. Only x (linear forward,
+      index 0) and rz (angular yaw, index 5) are used; arrays of any other
+      length are ignored. The node accepts this command under any input id.
+
+outputs: {}
+
+env:
+  SERIAL_PORT:
+    type: string
+    default: "/dev/ttyUSB0"
+    description: Serial port device the car chassis is connected to.
+
+example: |
+  - id: dora-kit-car
+    hub: dora-kit-car@^0.3
+    inputs:
+      tick: keyboard-listener/twist
+    env:
+      SERIAL_PORT: /dev/ttyUSB0

--- a/node-hub/dora-mcp-host/README.md
+++ b/node-hub/dora-mcp-host/README.md
@@ -1,22 +1,73 @@
-# Dora MCP Host
+# dora-mcp-host
 
-## Overview
+A Model Context Protocol (MCP) host node. It exposes an OpenAI-compatible HTTP
+API, routes chat completions to multiple AI providers (OpenAI, Gemini, Deepseek)
+or back into the dataflow, and connects to MCP servers to expose their tools.
 
-Dora MCP Host is a Model Context Protocol (MCP) host implementation based on the Dora framework. It supports integration with multiple AI providers, tool calls, and local service extensions. The host is OpenAI API compatible and supports multiple models and custom local tools.
+## Behavior
 
-## Features
+On start, the node reads a config file (path from the `CONFIG` env var,
+defaulting to `config.toml`) and exits if the file is missing. It then starts an
+OpenAI-compatible HTTP server on the configured `listen_addr` (default
+`0.0.0.0:8008`) exposing `/v1/models` and `/v1/chat/completions`.
 
-- OpenAI API compatibility (`/v1/models`, `/v1/chat/completions`)
-- Multi-model, multi-provider routing
-- Tool calls and local service integration
+Incoming chat requests are routed by model id to a configured provider:
 
-## How to use
+- **openai / gemini / deepseek** providers call the upstream API directly over
+  HTTP.
+- A **dora** provider forwards the prompt into the dataflow. The node sends the
+  prompt text as a UTF-8 string array on the provider's configured output id,
+  tagged with a `__dora_call_id` metadata parameter. It then waits for an input
+  carrying the same `__dora_call_id`, wraps that text in a chat-completion
+  response, and returns it to the HTTP caller.
+
+MCP servers declared in the config (stdio or streamable HTTP transports) are
+started and their tools registered with the chat session.
+
+The node stops on a Dora `Stop` event or when the HTTP server task ends.
+
+## Inputs
+
+- `tick`: reply stream for the Dora provider. A node wired here receives the
+  prompt on the configured output and must reply with a UTF-8 string array
+  carrying the same `__dora_call_id` metadata parameter. The input is matched by
+  metadata, not by id, so any input id may be wired; inputs without a matching
+  `__dora_call_id` are warned and ignored.
+
+## Outputs
+
+- `tick`: the chat prompt forwarded to the dataflow when a request routes to the
+  Dora provider, emitted as a UTF-8 string array with a `__dora_call_id`
+  metadata parameter. The actual output id is set by the `output` field of the
+  Dora provider in the config file.
+
+## Environment variables
+
+- `CONFIG` (default `config.toml`): path to the config file (toml, json, or
+  yaml).
+- `GEMINI_API_KEY`, `GEMINI_API_URL`: fallback Gemini credentials/URL when not
+  set in the config.
+- `DEEPSEEK_API_KEY`, `DEEPSEEK_API_URL`: fallback Deepseek credentials/URL when
+  not set in the config.
+- `OPENAI_API_KEY`, `OPENAI_API_URL`: fallback OpenAI credentials/URL when not
+  set in the config.
+
+In the config file, an `api_key` value prefixed with `env:` is read from the
+named environment variable.
+
+## Usage
 
 ```yaml
 nodes:
+  - id: dora-echo
+    hub: dora-echo
+    inputs:
+      echo: dora-mcp-host/text
+    outputs:
+      - echo
+
   - id: dora-mcp-host
-    build: cargo build -p dora-mcp-host --release
-    path: ../../target/release/dora-mcp-host
+    hub: dora-mcp-host
     outputs:
       - text
     inputs:
@@ -25,45 +76,33 @@ nodes:
       CONFIG: mcp_host.toml
 ```
 
-use `CONFIG` set config file, it supports toml, json or yaml format.
-
-An example config file:
+Example `mcp_host.toml`:
 
 ```toml
 listen_addr = "0.0.0.0:8118"
 endpoint = "v1"
 
 [[providers]]
+id = "dora"
+kind = "dora"
+output = "text"
+
+[[providers]]
 id = "moonshot"
-kind ="openai"
+kind = "openai"
 api_key = "env:MOONSHOT_API_KEY"
 api_url = "https://api.moonshot.cn/v1"
-
-[[providers]]
-id = "gemini"
-kind ="gemini"
-api_key = "env:GEMINI_API_KEY"
-api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
-
-[[providers]]
-id = "dora"
-kind ="dora"
-output = "output"
 
 [[models]]
 id = "kimi-latest"
 route = { provider = "moonshot", model = "kimi-latest" }
-
-[[models]]
-id = "gemini-2.0-flash"
-route = { provider = "gemini", model = "gemini-2.0-flash" }
 
 [[mcp.servers]]
 name = "amap-maps"
 protocol = "stdio"
 command = "npx"
 args = ["-y", "@amap/amap-maps-mcp-server"]
-envs = {AMAP_MAPS_API_KEY = "your_amap_maps_api_key_here"}
+envs = { AMAP_MAPS_API_KEY = "your_amap_maps_api_key_here" }
 
 [[mcp.servers]]
 name = "local"
@@ -71,8 +110,11 @@ protocol = "streamable"
 url = "http://127.0.0.1:8228/mcp"
 ```
 
-In `[[providers]]` section, if `api_key` is starts with `env:`, it will get the value from the system's environment variables.
+The Dora provider's `output` field must match the output id wired in the
+dataflow (`text` above).
 
-In `[[models]]` section, we define local models that are provided for external access. These models will be routed to different AI providers in the route definition. In the above example, if the model requested by the user is kimi-latest, the request will be handled by moonshot. If the model requested is gemini-2.0-flash, the request will be handled by gemini.
+## Build
 
-In `[[mcp.servers]]` section, you can define multiple mcp servers for use.
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-mcp-host/README.md
+++ b/node-hub/dora-mcp-host/README.md
@@ -28,7 +28,7 @@ The node stops on a Dora `Stop` event or when the HTTP server task ends.
 
 ## Inputs
 
-- `tick`: reply stream for the Dora provider. A node wired here receives the
+- `text`: reply stream for the Dora provider. A node wired here receives the
   prompt on the configured output and must reply with a UTF-8 string array
   carrying the same `__dora_call_id` metadata parameter. The input is matched by
   metadata, not by id, so any input id may be wired; inputs without a matching
@@ -36,7 +36,7 @@ The node stops on a Dora `Stop` event or when the HTTP server task ends.
 
 ## Outputs
 
-- `tick`: the chat prompt forwarded to the dataflow when a request routes to the
+- `text`: the chat prompt forwarded to the dataflow when a request routes to the
   Dora provider, emitted as a UTF-8 string array with a `__dora_call_id`
   metadata parameter. The actual output id is set by the `output` field of the
   Dora provider in the config file.

--- a/node-hub/dora-mcp-host/dora-node.yml
+++ b/node-hub/dora-mcp-host/dora-node.yml
@@ -1,0 +1,88 @@
+apiVersion: 1
+name: dora-mcp-host
+namespace: dora-rs
+description: >-
+  A Model Context Protocol (MCP) host node. Exposes an OpenAI-compatible HTTP
+  API, routes chat completions to multiple AI providers (OpenAI, Gemini,
+  Deepseek) or back into the dataflow, and connects to MCP servers to expose
+  their tools.
+categories: [communication]
+keywords:
+  - mcp
+  - model-context-protocol
+  - openai
+  - llm
+  - chat-completions
+runtime: rust
+entrypoint: target/release/dora-mcp-host
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  tick:
+    description: >-
+      Reply stream for the Dora provider. A node wired here receives the chat
+      prompt on the configured output and must reply with a UTF-8 string array
+      carrying the same `__dora_call_id` metadata parameter that was sent with
+      the prompt. The input id is matched by metadata, not by name, so any id
+      may be wired.
+
+outputs:
+  tick:
+    description: >-
+      Chat prompt forwarded to the dataflow when a request routes to the Dora
+      provider. Emitted as a UTF-8 string array with a `__dora_call_id`
+      metadata parameter used to correlate the reply. The actual output id is
+      set by the `output` field of the Dora provider in the config file.
+
+env:
+  CONFIG:
+    type: string
+    default: config.toml
+    description: >-
+      Path to the host config file (toml, json, or yaml). The node exits if
+      the file does not exist.
+  GEMINI_API_KEY:
+    type: string
+    description: >-
+      Fallback API key for a Gemini provider when its `api_key` is not set in
+      the config file.
+  GEMINI_API_URL:
+    type: string
+    default: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+    description: >-
+      Fallback API URL for a Gemini provider when its `api_url` is not set in
+      the config file.
+  DEEPSEEK_API_KEY:
+    type: string
+    description: >-
+      Fallback API key for a Deepseek provider when its `api_key` is not set in
+      the config file.
+  DEEPSEEK_API_URL:
+    type: string
+    default: https://api.deepseek.com
+    description: >-
+      Fallback API URL for a Deepseek provider when its `api_url` is not set in
+      the config file.
+  OPENAI_API_KEY:
+    type: string
+    description: >-
+      Fallback API key for an OpenAI provider when its `api_key` is not set in
+      the config file.
+  OPENAI_API_URL:
+    type: string
+    default: https://api.openai.com/v1/chat/completions
+    description: >-
+      Fallback API URL for an OpenAI provider when its `api_url` is not set in
+      the config file.
+
+example: |
+  - id: dora-mcp-host
+    hub: dora-mcp-host
+    outputs:
+      - text
+    inputs:
+      text: dora-echo/echo
+    env:
+      CONFIG: mcp_host.toml

--- a/node-hub/dora-mcp-host/dora-node.yml
+++ b/node-hub/dora-mcp-host/dora-node.yml
@@ -20,7 +20,7 @@ dora: ">=0.3.9"
 platforms: []
 
 inputs:
-  tick:
+  text:
     description: >-
       Reply stream for the Dora provider. A node wired here receives the chat
       prompt on the configured output and must reply with a UTF-8 string array
@@ -29,7 +29,7 @@ inputs:
       may be wired.
 
 outputs:
-  tick:
+  text:
     description: >-
       Chat prompt forwarded to the dataflow when a request routes to the Dora
       provider. Emitted as a UTF-8 string array with a `__dora_call_id`

--- a/node-hub/dora-mcp-host/src/main.rs
+++ b/node-hub/dora-mcp-host/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> eyre::Result<()> {
                         .collect::<Vec<_>>();
                     node.send_output(
                         DataId::from(output),
-                        Default::default(),
+                        metadata,
                         StringArray::from(texts),
                     )
                     .context("failed to send dora output")?;

--- a/node-hub/dora-mcp-server/README.md
+++ b/node-hub/dora-mcp-server/README.md
@@ -1,66 +1,73 @@
-# Dora MCP Server
+# dora-mcp-server
 
-This node can provide an MCP Server, which will proxy the request to one or more other nodes in the dora application.
+A Model Context Protocol (MCP) server node. It exposes the surrounding dataflow
+as MCP tools over HTTP: incoming tool calls are forwarded to other dora nodes as
+outputs, and their replies are returned to the MCP client as tool results.
 
-Dora MCP Server is still experimental and may change in the future.
+## Behavior
 
+On startup the node loads a config file (path from the `CONFIG` env var,
+default `config.toml`) describing the server identity and the list of MCP tools
+to expose. If the file is missing or invalid the node exits with an error.
 
-## How to use
+It then binds an HTTP server (default `0.0.0.0:8008`, path `/mcp`) and connects
+as a dora node, serving two request paths:
+
+- **HTTP MCP requests**: an MCP client POSTs JSON-RPC requests (`initialize`,
+  `ping`, `tools/list`, `tools/call`). For `tools/call`, the node looks up the
+  tool's configured `output`, sends the call parameters on that dora output with
+  a generated `__dora_call_id` in the metadata, and waits for the matching reply
+  before returning the result to the client.
+
+- **`request` dora input**: a JSON-RPC MCP request supplied as a dora input
+  string. The result is emitted on the `response` output.
+
+When a tool is invoked, the downstream node is expected to send its result back
+as a dora input carrying the same `__dora_call_id` metadata key. The node uses
+that id to match the reply to the pending call and resolve it.
+
+## Inputs
+
+- `request`: a JSON-RPC MCP request as a UTF-8 string. Its result is emitted on
+  `response`.
+- `tick`: tool-call replies from downstream nodes. Each reply must carry the
+  originating `__dora_call_id` metadata key so it is matched to the pending MCP
+  call; the reply body is returned to the MCP client as the tool result. Reply
+  input ids are config-driven (one per tool output target), so they are declared
+  under the single catch-all `tick` input.
+
+## Outputs
+
+- `response`: the JSON-RPC MCP result (UTF-8 string) for a `request` input.
+
+Tool calls additionally emit on per-tool output ids defined in the config file
+(`mcp_tools[].output`). These are config-driven and therefore not fixed in this
+contract; wire each tool's output node accordingly.
+
+## Environment variables
+
+- `CONFIG` (string, default `config.toml`): path to the MCP server config file.
+  The format is inferred from the extension (`.toml`, `.json`, `.yaml`/`.yml`).
+  It defines the server name/version, listen address, HTTP endpoint, and the MCP
+  tools to expose.
+
+## Usage
 
 ```yaml
 nodes:
-  - id: mcp-server
-    build: cargo build -p dora-mcp-server --release
-    path: ../../target/release/dora-mcp-server
-    outputs:
-      - counter
+  - id: dora-mcp-server
+    hub: dora-mcp-server@^0.3
     inputs:
-      counter_reply: counter/reply
+      request: client/request
+      tick: my-tool-node/result
+    outputs:
+      - response
     env:
       CONFIG: config.toml
 ```
 
-use `CONFIG` set config file, it supports toml, json or yaml format.
-
-An example config file:
-
-```toml
-name = "MCP Server Example"
-version = "0.1.0"
-
-# You can set your custom listen address and endpoint here.
-# Default listen address is "0.0.0.0:8008" and endpoint is "mcp".
-# In this example, the final service url is: http://0.0.0.0:8181/mcp
-listen_addr = "0.0.0.0:8181"
-endpoint = "mcp"
-
-[[mcp_tools]]
-name = "counter_decrement" # (Required) type: String, Unique identifier for the tool
-title = "Decrement Counter" # (Optional) type: String, Human-readable name of the tool for display purposes
-input_schema = "empty_object.json" # (Required) JSON Schema defining expected parameters
-output = "counter" # (Required) type: String, Set the output name
-[mcp_tools.annotations] # (Optional) Additional properties describing a Tool to clients
-title = "decrement current value of the counter" # type: String, A human-readable title for the tool
-
-[[mcp_tools]]
-name = "counter_increment"
-title = "Increment Counter"
-input_schema = "empty_object.json"
-output = "counter"
-[mcp_tools.annotations]
-title = "Increment current value of the counter"
-
-[[mcp_tools]]
-name = "counter_get_value"
-title = "Get Counter Value"
-input_schema = "empty_object.json"
-output = "counter"
-[mcp_tools.annotations]
-title = "Get the current value of the counter"
-```
-
-You can use mpc inspector to test:
+## Build
 
 ```bash
-npx @modelcontextprotocol/inspector
+cargo build --release --target-dir target
 ```

--- a/node-hub/dora-mcp-server/dora-node.yml
+++ b/node-hub/dora-mcp-server/dora-node.yml
@@ -1,0 +1,61 @@
+# Node manifest (the typed Hub contract) for `dora-mcp-server`.
+# Spec: docs/plan-node-hub.md §5 in dora-rs/dora. Published verbatim into the
+# Hub index by `dora hub publish`.
+apiVersion: 1
+name: dora-mcp-server
+namespace: dora-rs
+description: >-
+  Model Context Protocol (MCP) server node — exposes the dataflow as MCP tools
+  over HTTP. Tool calls are forwarded to other dora nodes as outputs and their
+  replies are returned as MCP results.
+categories: [communication]
+keywords: [mcp, model-context-protocol, server, tools, http, llm]
+
+runtime: rust
+entrypoint: target/release/dora-mcp-server
+# `--target-dir target` is required for workspace-member nodes: Hub builds and
+# spawns rooted at the subdir and resolves `entrypoint` confined to it, but a
+# plain `cargo build` writes to the *workspace* target dir (outside the subdir).
+# This keeps the binary package-local at <subdir>/target/release/dora-mcp-server.
+build: cargo build --release --target-dir target
+platforms: []
+dora: ">=0.3.9"
+
+# The node accepts an MCP request stream (`request`) and, for each configured
+# tool, forwards the call to a downstream node via a per-tool output id (set in
+# the config file's `mcp_tools[].output`). The downstream node's reply arrives
+# back as an input carrying a `__dora_call_id` metadata key; the node matches it
+# to the pending call. Because those reply input ids are config-driven (one per
+# tool output target) and not fixed in code, they are declared here under a
+# single catch-all `tick` input — wire each tool's reply stream to `tick`.
+inputs:
+  request:
+    required: false
+    description: A JSON-RPC MCP request (e.g. initialize, tools/list, tools/call) as a UTF-8 string. The response is emitted on `response`.
+  tick:
+    required: false
+    description: Tool-call replies from downstream nodes. Each reply must carry the originating `__dora_call_id` metadata key so it is matched to the pending MCP call; the reply body (UTF-8 string) is returned as the MCP CallToolResult.
+
+# `response` is the fixed reply to a `request` input. Tool calls additionally
+# emit on per-tool output ids defined in the config file (`mcp_tools[].output`),
+# which are config-driven and not enumerable here.
+outputs:
+  response:
+    description: The JSON-RPC MCP result (UTF-8 string) for a `request` input.
+
+env:
+  CONFIG:
+    type: string
+    default: config.toml
+    description: Path to the MCP server config file (TOML/JSON/YAML; format inferred from extension). Defines the server name/version, listen address, HTTP endpoint, and the MCP tools to expose.
+
+example: |
+  - id: dora-mcp-server
+    hub: dora-mcp-server@^0.3
+    inputs:
+      request: client/request
+      tick: my-tool-node/result
+    outputs:
+      - response
+    env:
+      CONFIG: config.toml

--- a/node-hub/dora-mistral-rs/README.md
+++ b/node-hub/dora-mistral-rs/README.md
@@ -1,0 +1,41 @@
+# dora-mistral-rs
+
+LLM text generation via [mistral.rs](https://github.com/EricLBuehler/mistral.rs) — receives a prompt string and emits the generated completion.
+
+## Behavior
+
+`dora-mistral-rs` connects as a dora node and builds a text model with mistral.rs's `TextModelBuilder`, loading the model named by `MODEL_PATH_OR_NAME` (defaults to `Qwen/Qwen2.5-0.5B-Instruct`).
+
+For each `text` input it receives, it reads the UTF-8 string, sends it to the model as a single user-role chat message, and emits the first choice's content string as a `text` output. The output carries the input event's metadata parameters.
+
+Input events with any other id are logged to stderr and otherwise ignored.
+
+## Inputs
+
+- `text`: prompt string sent to the model as a user message.
+
+## Outputs
+
+- `text`: generated completion text returned by the model.
+
+## Environment variables
+
+- `MODEL_PATH_OR_NAME` (string, default `Qwen/Qwen2.5-0.5B-Instruct`): Hugging Face model id or local path loaded by mistral.rs.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-mistral-rs
+    hub: dora-mistral-rs@^0.1
+    inputs:
+      text: prompt-source/text
+    env:
+      MODEL_PATH_OR_NAME: Qwen/Qwen2.5-0.5B-Instruct
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-mistral-rs/dora-node.yml
+++ b/node-hub/dora-mistral-rs/dora-node.yml
@@ -1,0 +1,33 @@
+apiVersion: 1
+name: dora-mistral-rs
+namespace: dora-rs
+description: LLM text generation via mistral.rs — receives a prompt string and emits the generated completion.
+categories: [llm]
+keywords: [llm, mistral, inference, text-generation, chat]
+runtime: rust
+entrypoint: target/release/dora-mistral-rs
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  text:
+    description: Prompt string sent to the model as a user message.
+
+outputs:
+  text:
+    description: Generated completion text returned by the model.
+
+env:
+  MODEL_PATH_OR_NAME:
+    type: string
+    default: Qwen/Qwen2.5-0.5B-Instruct
+    description: Hugging Face model id or local path loaded by mistral.rs TextModelBuilder.
+
+example: |
+  - id: dora-mistral-rs
+    hub: dora-mistral-rs@^0.1
+    inputs:
+      text: prompt-source/text
+    env:
+      MODEL_PATH_OR_NAME: Qwen/Qwen2.5-0.5B-Instruct

--- a/node-hub/dora-object-to-pose/README.md
+++ b/node-hub/dora-object-to-pose/README.md
@@ -1,0 +1,72 @@
+# dora-object-to-pose
+
+Convert detected objects (2D bounding boxes or segmentation masks) plus a depth
+frame into 3D poses. Masked/boxed pixels are projected into camera space using
+the depth frame, rotated by the configured camera pitch, and reduced to one
+`xyzrpy` pose per object.
+
+## Behavior
+
+`dora-object-to-pose` connects as a dora node and handles four input ids:
+
+- **`depth`**: a UInt16 depth frame (millimetres). It is cached for later
+  projection. Metadata parameters `height`, `width`, `focal`, and `resolution`,
+  if present, override the projection defaults.
+- **`image`**: a UInt8 image buffer. It is cached on receipt but is not used to
+  compute poses.
+- **`masks`**: segmentation masks (Float32 where `>0` means set, or Boolean),
+  flattened into chunks of `height*width` pixels — one chunk per object. For
+  each mask, the set pixels are projected into 3D using the cached `depth`
+  frame and reduced to a pose. Emits `pose`.
+- **`boxes2d`**: 2D bounding boxes as Int64 in chunks of 4
+  `[x_min, y_min, x_max, y_max]`. For each box, the depth pixels inside the box
+  are projected, filtered to the nearer half (by a mean/min-z threshold), and
+  reduced to a pose. Emits `pose`.
+
+Projection uses the depth value at each pixel divided by 1000, skipping empty or
+too-far points, then rotates by `CAMERA_PITCH`. Each pose is computed from the
+projected points' bounding extents and their x/y correlation (used as yaw). A
+`pose` output is only produced when a `depth` frame has already been received;
+otherwise the node logs that no depth frame was found. Any other input id is
+logged and ignored.
+
+## Inputs
+
+- `depth` (required): UInt16 depth frame (mm), row-major `width*height`.
+  Optional metadata parameters: `height`, `width`, `focal` (ListInt[2]),
+  `resolution` (ListInt[2]).
+- `masks`: Float32 (`>0` = set) or Boolean masks, flattened in `height*width`
+  chunks (one per object). Produces `pose`.
+- `boxes2d`: Int64 boxes in chunks of 4 `[x_min, y_min, x_max, y_max]`. Produces
+  `pose`.
+- `image`: UInt8 image buffer; cached but not used to compute poses.
+
+## Outputs
+
+- `pose`: flattened Float32 poses, 6 values per object
+  `[x, y, z, roll(0), pitch(0), yaw]`. Carries an `encoding: xyzrpy` metadata
+  parameter.
+
+## Environment variables
+
+- `CAMERA_PITCH` (float, default `2.47`): camera pitch in radians, used to
+  rotate projected points into the world frame.
+
+## Usage
+
+Wire a depth frame plus a detection stream (`boxes2d` or `masks`) into the node:
+
+```yaml
+nodes:
+  - id: dora-object-to-pose
+    hub: dora-object-to-pose@^0.5
+    inputs:
+      depth: camera/depth
+      boxes2d: detector/boxes2d
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-object-to-pose/dora-node.yml
+++ b/node-hub/dora-object-to-pose/dora-node.yml
@@ -1,0 +1,65 @@
+# Node manifest (the typed Hub contract) for `dora-object-to-pose`.
+# Spec: docs/plan-node-hub.md §5 in dora-rs/dora. Published verbatim into the
+# Hub index by `dora hub publish`.
+apiVersion: 1
+name: dora-object-to-pose
+namespace: dora-rs
+description: >-
+  Convert detected objects (2D bounding boxes or segmentation masks) plus a
+  depth frame into 3D poses, projecting masked/boxed pixels to camera-space
+  points and reducing them to xyzrpy poses.
+categories: [transform, robot]
+keywords: [pose, depth, bounding-box, mask, 3d, projection, perception]
+
+runtime: rust
+entrypoint: target/release/dora-object-to-pose
+# `--target-dir target` is required for workspace-member nodes: Hub builds and
+# spawns rooted at the subdir and resolves `entrypoint` confined to it, but a
+# plain `cargo build` writes to the *workspace* target dir (outside the subdir).
+# This keeps the binary package-local at <subdir>/target/release/dora-object-to-pose.
+build: cargo build --release --target-dir target
+platforms: []
+dora: ">=0.3.9"
+
+# A `pose` output is produced when a `masks` or `boxes2d` input arrives AND a
+# `depth` frame has already been cached. `depth` must therefore be wired and
+# arrive first. `image` is cached but not used to compute poses.
+inputs:
+  depth:
+    required: true
+    description: >-
+      UInt16 depth frame (millimetres), row-major width*height. Optional
+      metadata parameters `height`, `width`, `focal` (ListInt[2]),
+      `resolution` (ListInt[2]) override the projection defaults.
+  masks:
+    required: false
+    description: >-
+      Segmentation masks, Float32 (>0 = set) or Boolean, flattened in
+      chunks of height*width pixels — one chunk per object. Produces `pose`.
+  boxes2d:
+    required: false
+    description: >-
+      2D bounding boxes as Int64 in chunks of 4 [x_min, y_min, x_max, y_max].
+      Produces `pose`.
+  image:
+    required: false
+    description: UInt8 image buffer; cached on receipt but not used to compute poses.
+
+outputs:
+  pose:
+    description: >-
+      Flattened Float32 poses, 6 values per object [x, y, z, roll(0), pitch(0),
+      yaw]. Carries an `encoding: xyzrpy` metadata parameter.
+
+env:
+  CAMERA_PITCH:
+    type: float
+    default: 2.47
+    description: Camera pitch in radians, used to rotate projected points into the world frame.
+
+example: |
+  - id: dora-object-to-pose
+    hub: dora-object-to-pose@^0.5
+    inputs:
+      depth: camera/depth
+      boxes2d: detector/boxes2d

--- a/node-hub/dora-openai-websocket/README.md
+++ b/node-hub/dora-openai-websocket/README.md
@@ -1,0 +1,75 @@
+# dora-openai-websocket
+
+Bridges a dora dataflow to the OpenAI Realtime/websocket API. It runs an HTTP +
+WebSocket server that speaks the OpenAI Realtime protocol so OpenAI-compatible
+clients can talk to a dora-backed model pipeline.
+
+## Behavior
+
+On startup the node binds an HTTP/WebSocket server (default `0.0.0.0:8123`) and
+connects as a dora node. It serves four routes:
+
+- `/realtime`, `/v1/realtime` — WebSocket upgrade speaking the OpenAI Realtime
+  protocol.
+- `/v1/chat/completions` — OpenAI chat-completions endpoint (non-streaming;
+  streaming requests are answered with a full response).
+- `/models`, `/v1/models` — lists a single static model (`gpt-5`).
+
+When a Realtime client connects and sends a `session.update`, the node emits the
+session `instructions` as `system_prompt` and the `tools` list as `tools`.
+Client `input_audio_buffer.append` audio is base64-decoded, converted from PCM16
+to float32, and emitted as `audio` (with `sample_rate: 16000` metadata). Client
+`conversation.item.create` message items are emitted as `text`,
+`function_call_output` items as `function_call_output`, and `response.create`
+instructions (and chat-completion requests) as `response.create`.
+
+In the other direction, dora inputs are streamed back to the connected client as
+Realtime events: `audio` becomes PCM16 `response.audio.delta` + `response.done`,
+`text` becomes `response.text.delta` (or function-call events when wrapped in
+`<tool_call>`), `transcript` becomes `response.audio_transcript.delta`, and the
+speech inputs become `input_audio_buffer.speech_started` /
+`input_audio_buffer.speech_stopped`. Inputs are matched by substring on the id.
+
+## Inputs
+
+- `audio`: float32 PCM audio, sent to the client as audio deltas.
+- `text`: Utf8 assistant text, sent as text deltas (or function-call events).
+- `transcript`: Utf8 transcription text, sent as transcript deltas.
+- `speech_started`: signals the user started speaking.
+- `speech_stopped`: signals the user stopped speaking.
+
+## Outputs
+
+- `audio`: float32 PCM audio decoded from client audio appends
+  (`sample_rate: 16000` metadata).
+- `text`: Utf8 text from client conversation message items.
+- `system_prompt`: Utf8 session instructions from `session.update`.
+- `tools`: Utf8 JSON tool list from `session.update`.
+- `function_call_output`: Utf8 output from `function_call_output` items.
+- `response.create`: Utf8 prompt text from client `response.create` or a
+  chat-completions request.
+
+## Environment variables
+
+- `HOST` (string, default `0.0.0.0`): address the server binds to.
+- `PORT` (string, default `8123`): TCP port the server listens on.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-openai-websocket
+    hub: dora-openai-websocket@^0.5
+    inputs:
+      audio: tts/audio
+      text: llm/text
+      transcript: stt/transcript
+    env:
+      PORT: "8123"
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-openai-websocket/dora-node.yml
+++ b/node-hub/dora-openai-websocket/dora-node.yml
@@ -1,0 +1,92 @@
+apiVersion: 1
+name: dora-openai-websocket
+namespace: dora-rs
+description: >-
+  Bridges a dora dataflow to the OpenAI Realtime/websocket API. Runs an HTTP +
+  WebSocket server that speaks the OpenAI Realtime protocol (`/realtime`,
+  `/v1/realtime`), a chat-completions endpoint (`/v1/chat/completions`), and a
+  models listing (`/models`, `/v1/models`). Incoming client audio/text is
+  forwarded as dora outputs; dora inputs (audio, text, transcripts, speech
+  events) are streamed back to the connected client as Realtime events.
+categories: [llm, communication]
+keywords: [openai, realtime, websocket, llm, audio, chat-completions, bridge]
+runtime: rust
+entrypoint: target/release/dora-openai-websocket
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  audio:
+    description: >-
+      Arrow float32 PCM audio samples from the dataflow. Converted to PCM16,
+      base64-encoded, and sent to the connected client as a
+      `response.audio.delta` followed by a `response.done` event. Matched by the
+      substring `audio` in the input id.
+  text:
+    description: >-
+      Arrow Utf8 assistant text. Sent to the client as a `response.text.delta`;
+      if the text is wrapped in `<tool_call>...</tool_call>` (or parses as a tool
+      call) it is emitted as Realtime function-call events instead. Matched by
+      the substring `text` in the input id.
+  transcript:
+    description: >-
+      Arrow Utf8 transcription text. Sent to the client as a
+      `response.audio_transcript.delta` event. Matched by the substring
+      `transcript` in the input id.
+  speech_started:
+    description: >-
+      Signals that the user started speaking. Forwarded to the client as an
+      `input_audio_buffer.speech_started` event. Matched by the substring
+      `speech_started` in the input id.
+  speech_stopped:
+    description: >-
+      Signals that the user stopped speaking. Forwarded to the client as an
+      `input_audio_buffer.speech_stopped` event. Matched by the substring
+      `speech_stopped` in the input id.
+
+outputs:
+  audio:
+    description: >-
+      Arrow float32 PCM audio decoded from client `input_audio_buffer.append`
+      events. Metadata carries `sample_rate: 16000`.
+  text:
+    description: >-
+      Arrow Utf8 text extracted from client `conversation.item.create` message
+      items (input_text, text, and image-url content parts).
+  system_prompt:
+    description: >-
+      Arrow Utf8 system prompt taken from the `session.update` instructions when
+      a client establishes a Realtime session.
+  tools:
+    description: >-
+      Arrow Utf8 JSON-encoded tool list taken from the `session.update` tools
+      field when a client establishes a Realtime session.
+  function_call_output:
+    description: >-
+      Arrow Utf8 output of a client `conversation.item.create` item of type
+      `function_call_output`.
+  response.create:
+    description: >-
+      Arrow Utf8 prompt text emitted from a client `response.create`
+      instructions field or from a `/v1/chat/completions` request.
+
+env:
+  HOST:
+    type: string
+    default: 0.0.0.0
+    description: Address the HTTP/WebSocket server binds to.
+  PORT:
+    type: string
+    default: "8123"
+    description: TCP port the HTTP/WebSocket server listens on.
+
+example: |
+  - id: dora-openai-websocket
+    hub: dora-openai-websocket@^0.5
+    inputs:
+      audio: tts/audio
+      text: llm/text
+      transcript: stt/transcript
+    env:
+      PORT: "8123"

--- a/node-hub/dora-qwen-omni/README.md
+++ b/node-hub/dora-qwen-omni/README.md
@@ -1,27 +1,74 @@
-# Rust mtmd-cli implementation
+# dora-qwen-omni
 
-Partial port of the mtmd-cli.cpp example in the llama-cpp repository.
+Multimodal llama.cpp (mtmd) node. It loads a GGUF model plus a multimodal
+projection file and, for each input event, builds a chat prompt from the
+received strings, runs the model, and emits the generated text.
+
+## Behavior
+
+The node connects as a dora node (`init_from_env`) and loops over input events.
+For every input event it:
+
+- Clears the chat history and KV cache.
+- Reads the input data as a UTF-8 string array and inspects each string by
+  prefix marker:
+  - `<|user|>\n<|im_start|>\n` — the remainder is appended to the text prompt.
+  - `<|user|>\n<|vision_start|>\n` — the remainder is treated as an image. A
+    `data:image/...` base64 data URI is decoded inline; otherwise, if the value
+    parses as a URL it is fetched with a blocking HTTP GET. The loaded image is
+    added as a media bitmap and a default media marker is inserted into the
+    prompt.
+  - `<|system|>\n` — ignored.
+  - Anything else — appended to the text prompt.
+- Evaluates the assembled user message and generates a response, then emits it.
+
+The input id is not inspected — any wired input triggers a turn. Model,
+multimodal projection, prompt, and runtime knobs are supplied as command-line
+arguments (clap), not environment variables. `--model` and `--mmproj` must
+point to existing files or the process exits before connecting.
+
+## Inputs
+
+- `tick`: any input event. Its data is read as a string array and parsed by the
+  markers described above. The input id itself is ignored.
+
+## Outputs
+
+- `text`: the model's generated text response for the received prompt/image.
+
+## Environment variables
+
+None. Configuration is passed via command-line arguments:
+
+- `--model <PATH>` (required): path to the GGUF model file.
+- `--mmproj <PATH>` (required): path to the multimodal projection file.
+- `--prompt <TEXT>` (required): text prompt.
+- `--image <PATH>`, `--audio <PATH>`: media file paths (repeatable).
+- `--n-predict <N>` (default 4096), `--threads <N>` (default 128),
+  `--n-tokens <N>` (default 16384), `--chat-template <TEMPLATE>`,
+  `--no-gpu`, `--no-mmproj-offload`, `--marker <TEXT>`.
 
 ## Usage
 
-### Command Line Interface
+Because the required model/prompt settings are CLI arguments, run the node via
+`path:` with `args:` (a `hub:` reference cannot pass command-line arguments):
 
-To run the mtmd example, you first need to download the model gguf file and the multimodal projection file, e.g. for Gemma3 you may use:
-
-```sh
-wget https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q4_K_M.gguf \
-https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/mmproj-F16.gguf
+```yaml
+nodes:
+  - id: dora-qwen-omni
+    build: cargo build --release --target-dir target
+    path: target/release/dora-qwen-omni
+    args: >-
+      --model ./model.gguf --mmproj ./mmproj.gguf
+      --prompt "What is in the picture?"
+    inputs:
+      tick: some-node/output
+    outputs:
+      - text
 ```
 
-To then run the example on CPU, provide an image file `my_image.jpg` and run:
+## Build
 
-```sh
-cargo run --release --example mtmd -- \
-  --model ./gemma-3-4b-it-Q4_K_M.gguf \
-  --mmproj ./mmproj-F16.gguf \
-  --image my_image.jpg \
-  --prompt "What is in the picture?" \
-  --no-gpu \
-  --no-mmproj-offload \
-  --marker "<start_of_image>"
+```bash
+cargo build --release --target-dir target
 ```

--- a/node-hub/dora-qwen-omni/dora-node.yml
+++ b/node-hub/dora-qwen-omni/dora-node.yml
@@ -1,0 +1,42 @@
+apiVersion: 1
+name: dora-qwen-omni
+namespace: dora-rs
+description: >-
+  Multimodal llama.cpp (mtmd) node. Receives prompt/image strings on a dora
+  input, runs a GGUF model with a multimodal projection, and emits the
+  generated text. Decodes inline base64 images and fetches image URLs found in
+  the input.
+categories: [ml-inference, llm]
+keywords: [llama-cpp, multimodal, mtmd, gguf, vision, qwen]
+runtime: rust
+entrypoint: target/release/dora-qwen-omni
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  tick:
+    description: >-
+      Any input event. Its data is read as a UTF-8 string array. Lines are
+      parsed by prefix marker: `<|user|>\n<|im_start|>\n` is treated as text
+      prompt, `<|user|>\n<|vision_start|>\n` as an image (either a
+      `data:image/...` base64 data URI or an http(s) URL that is fetched), and
+      `<|system|>\n` lines are ignored. The input id itself is not inspected.
+
+outputs:
+  text:
+    description: The model's generated text response for the received prompt/image.
+
+env: {}
+
+example: |
+  - id: dora-qwen-omni
+    build: cargo build --release --target-dir target
+    path: target/release/dora-qwen-omni
+    args: >-
+      --model ./model.gguf --mmproj ./mmproj.gguf
+      --prompt "What is in the picture?"
+    inputs:
+      tick: some-node/output
+    outputs:
+      - text

--- a/node-hub/dora-rav1e/README.md
+++ b/node-hub/dora-rav1e/README.md
@@ -28,8 +28,10 @@ The encoded frame is sent back out under the **same input id** it arrived on.
   uint16 (`mono16`, `z16`). Pixel format, width, and height are taken from the
   input metadata when present.
 
-The node re-emits under whatever id it received, so the input may be wired under
-any id; `image` is the conventional one.
+The node re-emits under whatever id it received, so when launched via `path:` the
+input may be wired under any id; `image` is the conventional one. Under a `hub:`
+contract, wire the input on the declared `image` id — the hub permits only
+declared input ids.
 
 ## Outputs
 

--- a/node-hub/dora-rav1e/README.md
+++ b/node-hub/dora-rav1e/README.md
@@ -1,0 +1,71 @@
+# dora-rav1e
+
+AV1 video encoder built on [rav1e](https://crates.io/crates/rav1e). Encodes raw
+image frames into AV1 or AVIF byte streams.
+
+## Behavior
+
+`dora-rav1e` connects as a dora node and encodes every image frame it receives.
+For each input it:
+
+- Reads `width`/`height` from the input metadata (falling back to the
+  `IMAGE_WIDTH`/`IMAGE_HEIGHT` env vars) and the pixel format from the metadata
+  `encoding` parameter (default `bgr8`).
+- Converts the frame to YUV (or mono for `mono16`/`z16`) and encodes it with
+  rav1e using the `RAV1E_SPEED` preset and low-latency settings.
+- Wraps the result as AVIF when `ENCODING=avif`, otherwise emits raw AV1
+  packets.
+
+Supported input pixel formats: `bgr8`, `rgb8`, `yuv420`, `mono16`, `z16`. For
+`mono16`/`z16`, zero pixels are filled toward the row center unless
+`FILL_ZEROS=false`. Any other format triggers an `unimplemented!` panic.
+
+The encoded frame is sent back out under the **same input id** it arrived on.
+
+## Inputs
+
+- `image`: raw image frame to encode. Arrow uint8 (`bgr8`, `rgb8`, `yuv420`) or
+  uint16 (`mono16`, `z16`). Pixel format, width, and height are taken from the
+  input metadata when present.
+
+The node re-emits under whatever id it received, so the input may be wired under
+any id; `image` is the conventional one.
+
+## Outputs
+
+- `image`: encoded frame as Arrow uint8 bytes. Output metadata carries
+  `encoding` (`av1` or `avif`), `primitive: image`, and for AV1 also `width` and
+  `height`.
+
+## Environment variables
+
+- `IMAGE_HEIGHT` (int, default `480`): default frame height when no `height`
+  input metadata is present.
+- `IMAGE_WIDTH` (int, default `640`): default frame width when no `width` input
+  metadata is present.
+- `RAV1E_SPEED` (int, default `10`): rav1e speed preset (0 = slowest/best
+  quality, 10 = fastest).
+- `ENCODING` (string, default `av1`): output codec/container — `av1` for raw AV1
+  packets, `avif` for AVIF-wrapped output.
+- `FILL_ZEROS` (bool, default `true`): for `mono16`/`z16`, fill zero pixels
+  toward the row center before encoding. Set to `false` to disable.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-rav1e
+    hub: dora-rav1e@^0.3
+    inputs:
+      image: camera/image
+    env:
+      ENCODING: avif
+      IMAGE_WIDTH: 640
+      IMAGE_HEIGHT: 480
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-rav1e/dora-node.yml
+++ b/node-hub/dora-rav1e/dora-node.yml
@@ -1,0 +1,62 @@
+apiVersion: 1
+name: dora-rav1e
+namespace: dora-rs
+description: >-
+  AV1 video encoder built on rav1e. Takes raw image frames (bgr8, rgb8, yuv420,
+  mono16/z16) and encodes them into AV1 or AVIF byte streams.
+categories: [transform]
+keywords: [av1, avif, rav1e, video, encoder, image, codec]
+runtime: rust
+entrypoint: target/release/dora-rav1e
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  image:
+    description: >-
+      Raw image frame to encode. Arrow uint8 (bgr8, rgb8, yuv420) or uint16
+      (mono16, z16). The frame pixel format is read from the input metadata
+      `encoding` parameter (defaults to `bgr8`); `width`/`height` metadata
+      parameters override the IMAGE_WIDTH/IMAGE_HEIGHT env defaults.
+
+outputs:
+  image:
+    description: >-
+      Encoded frame as Arrow uint8 bytes. Output metadata carries `encoding`
+      (`av1` or `avif`), `primitive: image`, plus `width`/`height` for AV1
+      output. The encoder re-emits under the same id it received the input on.
+
+env:
+  IMAGE_HEIGHT:
+    type: int
+    default: 480
+    description: Default frame height in pixels, used when no `height` input metadata is present.
+  IMAGE_WIDTH:
+    type: int
+    default: 640
+    description: Default frame width in pixels, used when no `width` input metadata is present.
+  RAV1E_SPEED:
+    type: int
+    default: 10
+    description: rav1e speed preset (0 = slowest/best quality, 10 = fastest).
+  ENCODING:
+    type: string
+    default: av1
+    description: Output container/codec. `av1` for raw AV1 packets, `avif` for AVIF-wrapped output.
+  FILL_ZEROS:
+    type: bool
+    default: true
+    description: >-
+      For mono16/z16 depth frames, fill zero pixels toward the row center before
+      encoding. Set to `false` to disable.
+
+example: |
+  - id: dora-rav1e
+    hub: dora-rav1e@^0.3
+    inputs:
+      image: camera/image
+    env:
+      ENCODING: avif
+      IMAGE_WIDTH: 640
+      IMAGE_HEIGHT: 480

--- a/node-hub/dora-record/README.md
+++ b/node-hub/dora-record/README.md
@@ -1,56 +1,61 @@
 # dora-record
 
-dora data recording using Apache Arrow Parquet.
+Record dataflow inputs to disk. For every input it receives, `dora-record`
+appends a row to a Brotli-compressed Apache Parquet file, capturing the value
+together with UHLC and UTC timestamps and the OpenTelemetry trace/span ids.
 
-This nodes is still experimental.
+## Behavior
 
-## Getting Started
+`dora-record` connects as a dora node and, for each input event, writes to
+`out/<dataflow-id>/<input-id>.parquet`. The first time it sees a given input id
+it creates the file, derives the schema from that input's Arrow data type, and
+spawns a dedicated writer task; subsequent events for the same id stream into
+that file. Each row contains:
 
-```bash
-cargo install dora-record --locked
-```
+- `trace_id`, `span_id` — parsed from the input's OpenTelemetry `traceparent`
+  (empty when absent).
+- `timestamp_uhlc` — the UHLC hybrid-logical-clock time as a `UInt64`.
+- `timestamp_utc` — the same instant as a millisecond UTC timestamp.
+- `<input-id>` — the input value wrapped in a single-element Arrow list.
 
-## Adding to existing graph:
+On `InputClosed` the corresponding writer is dropped (flushing and closing its
+file); remaining writers are closed when the dataflow ends.
+
+## Inputs
+
+- `data`: the stream to record. Any Arrow value — written verbatim to
+  `data.parquet` alongside timestamps and trace ids.
+
+The node itself records **any** input id it receives (one `<id>.parquet` file
+per id), but a `hub:` contract must declare every wired input (an undeclared
+input fails the build), so it declares one generic `data` input. To record
+arbitrary or multiple input names, run it directly via `path:` (where the
+contract isn't enforced) or use one instance per stream.
+
+## Outputs
+
+None — it is a sink.
+
+## Environment variables
+
+None.
+
+## Usage
+
+Wire a node's output into `dora-record`:
 
 ```yaml
-- id: dora-record
-  custom:
-    source: dora-record
+nodes:
+  - id: dora-record
+    hub: dora-record@^0.5
     inputs:
-      image: webcam/image
-      text: webcam/text
-      # You can add any input and it is going to be logged.
+      data: some-node/output
 ```
 
-## Output Files
+Recorded files land under `out/<dataflow-id>/data.parquet`.
 
-Format: Parquet file
+## Build
 
-path: `out/<DATAFLOW_ID>/<INPUT>.parquet`
-
-Columns:
-
-- trace_id: String, representing the id of the current trace
-- span_id: String, representing the unique span id
-- timestamp_uhlc: u64, representing the timestamp in [Unique Hybrid Logical Clock time](https://github.com/atolab/uhlc-rs)
-- timestamp_utc: DataType::Timestamp(Milliseconds), representing the timestamp in Coordinated Universal Time.
-- `<INPUT>` : Column containing the input in its defined format.
-
-Example:
-
-```json
-{
-  "trace_id": "2fd23ddf1b5d2aa38ddb86ceedb55928",
-  "span_id": "15aef03e0f052bbf",
-  "timestamp_uhlc": "7368873278370007008",
-  "timestamp_utc": 1715699508406,
-  "random": [1886295351360621740]
-}
+```bash
+cargo build --release --target-dir target
 ```
-
-## merging multiple file
-
-We can merge input files using the `trace_id` that is going to be shared when using opentelemetry features.
-
-- `trace_id` can also be queried from UI such as jaeger UI, influxDB and so on...
-- `trace_id` keep tracks of the logical flow of data, compared to timestamp based merging that might not reflect the actual logical flow of data.

--- a/node-hub/dora-record/dora-node.yml
+++ b/node-hub/dora-record/dora-node.yml
@@ -1,0 +1,41 @@
+# Node manifest (the typed Hub contract) for `dora-record`.
+# Spec: docs/plan-node-hub.md §5 in dora-rs/dora. Published verbatim into the
+# Hub index by `dora hub publish`.
+apiVersion: 1
+name: dora-record
+namespace: dora-rs
+description: >-
+  Record dataflow inputs to disk — writes each received input to a Brotli-
+  compressed Parquet file under out/<dataflow-id>/<input-id>.parquet, capturing
+  the value plus UHLC/UTC timestamps and OpenTelemetry trace/span ids.
+categories: [recorder]
+keywords: [record, recorder, parquet, sink, logging, dataset]
+
+runtime: rust
+entrypoint: target/release/dora-record
+# `--target-dir target` is required for workspace-member nodes: Hub builds and
+# spawns rooted at the subdir and resolves `entrypoint` confined to it, but a
+# plain `cargo build` writes to the *workspace* target dir (outside the subdir).
+# This keeps the binary package-local at <subdir>/target/release/dora-record.
+build: cargo build --release --target-dir target
+platforms: []
+dora: ">=0.3.9"
+
+# dora-record is a sink: it records whatever it receives and produces no outputs.
+# The code records *any* input id (one Parquet file per id, named <id>.parquet),
+# but a Hub contract must declare every wired input (an undeclared input fails
+# the build), so it declares one generic `data` input — wire your stream to
+# `data`. To record arbitrary/multiple input names, run it directly via `path:`
+# (where the contract isn't enforced) or use one instance per stream.
+inputs:
+  data:
+    required: false
+    description: The stream to record. Any Arrow value; written verbatim to data.parquet alongside timestamps and trace ids.
+
+outputs: {}
+
+example: |
+  - id: dora-record
+    hub: dora-record@^0.5
+    inputs:
+      data: some-node/output

--- a/node-hub/dora-rerun/README.md
+++ b/node-hub/dora-rerun/README.md
@@ -1,358 +1,87 @@
 # dora-rerun
 
-dora visualization using `rerun`
+Log images, depth, boxes, points, series, text, and URDF robot state to a
+[Rerun.io](https://rerun.io) viewer.
 
-This nodes is still experimental and format for passing Images, Bounding boxes, and text are probably going to change in the future.
+## Behavior
 
-## Changes in v0.24.0
+`dora-rerun` connects as a dora node and forwards every input event to a Rerun
+recording stream. On startup it chooses how to deliver data based on
+`OPERATING_MODE`:
 
-This version introduces significant breaking changes to align with Rerun SDK v0.24.0 and improve the visualization primitive system.
+- **SPAWN** (default): launches a local Rerun viewer.
+- **CONNECT**: connects over gRPC to a viewer at `RERUN_SERVER_ADDR`.
+- **SAVE**: writes a `.rerun` archive under `out/<dataflow-id>/`.
 
-### Backward Compatibility
+It also loads any URDF robots declared via `*_urdf` / `*_URDF` environment
+variables (optionally positioned with a matching `*_transform` variable), and
+logs the value of the `README` variable as a viewer text document if set.
 
-**✅ Soft Breaking Change**: While the new version prefers explicit `primitive` metadata, it includes automatic fallback detection from topic names for backward compatibility:
+For each input it picks a visualization primitive: it first reads a `primitive`
+metadata parameter, and if absent infers one from a keyword contained in the
+input id (e.g. an id containing `image`). An id containing more than one keyword,
+or an unknown primitive, is an error. The supported primitives are: `image`,
+`depth`, `text`, `boxes2d`, `boxes3d`, `masks`, `jointstate`, `pose`, `series`,
+`points3d`, `points2d`, and `lines3d` (the last is selectable only via the
+`primitive` metadata parameter).
 
-- If no `primitive` metadata is provided, the system silently infers it from the input ID/topic name
-- No warnings are generated to avoid log spam
-- Existing code continues to work without any changes
-- This allows gradual migration at your own pace
+Some primitives read extra per-message metadata parameters — for example
+`width`/`height`/`encoding` for `image` and `depth`, `format` for `boxes2d`/
+`boxes3d`, `color`/`radii`/`radius` for points and lines.
 
-Example migration:
+## Inputs
 
-```yaml
-# Old way (still works silently):
-inputs:
-  image: camera/image  # Primitive inferred from "image" in name
+The node selects behavior by primitive (from metadata or the input id). Declared
+input ids:
 
-# New way (recommended):
-inputs:
-  front_camera:
-    source: camera/image
-    metadata:
-      primitive: "image"  # Explicit primitive specification
-```
+- `image`: RGB/BGR or encoded (jpeg/png/avif) image bytes.
+- `depth`: depth map; rendered as a 3D DepthImage when camera metadata is present.
+- `text`: UTF-8 string array (Chinese characters are transliterated to pinyin).
+- `boxes2d`: 2D bounding boxes.
+- `boxes3d`: 3D bounding boxes.
+- `masks`: float or boolean mask array (cached).
+- `jointstate`: joint positions applied to a loaded URDF chain.
+- `pose`: joint positions applied to a loaded URDF chain.
+- `series`: float series logged as scalars.
+- `points3d`: flat array of xyz triples.
+- `points2d`: flat array of xy pairs.
+- `lines3d`: flat array of xyz triples forming a line strip.
 
-### Design Rationale
+## Outputs
 
-The move from input-name-based visualization to explicit primitive metadata was driven by real-world requirements from complex robotics applications, specifically a quad drone system with hierarchical sensor configurations. The previous system had limitations:
+None — it is a visualization sink.
 
-- Input names were tightly coupled to visualization types (e.g., input named "image" → image visualization)
-- Complex hierarchies weren't properly preserved in Rerun's scene graph
-- Multiple inputs of the same type required awkward naming conventions
-- Adding new visualization types required careful naming coordination
+## Environment variables
 
-**Pros of the new primitive-based system:**
+- `OPERATING_MODE`: `SPAWN` (default), `CONNECT`, or `SAVE`. Unknown values fall
+  back to `SPAWN`.
+- `RERUN_SERVER_ADDR`: gRPC address used in `CONNECT` mode. Default
+  `127.0.0.1:9876`.
+- `RERUN_MEMORY_LIMIT`: viewer memory limit (e.g. `25%` or `4GB`). Default `25%`.
+- `README`: optional Markdown text logged as a README document in the viewer.
+- `*_urdf` / `*_URDF`: each such variable points to a URDF file (or a
+  `*_description` robot-descriptions name) to load. An optional matching
+  `*_transform` variable (space-separated `x y z` or `x y z qx qy qz qw`)
+  positions it.
 
-- ✅ **Explicit intent**: Clear specification of visualization type via metadata
-- ✅ **Flexible naming**: Input names can be descriptive (e.g., `front_camera`, `rear_camera`) rather than generic
-- ✅ **Proper hierarchies**: Entity paths and relationships are correctly maintained in Rerun
-- ✅ **Extensibility**: New primitives can be added without affecting existing inputs
-- ✅ **Multiple same-type inputs**: Easy to have multiple cameras, depth sensors, etc.
-- ✅ **Better error messages**: System can report exactly what primitive was expected vs received
-
-**Cons to consider:**
-
-- ❌ **Breaking change**: All nodes sending to dora-rerun must be updated
-- ❌ **More verbose**: Requires metadata on every input
-- ❌ **Migration effort**: Existing systems need code changes
-- ❌ **Coordination required**: Senders and receivers must agree on primitive types
-
-**Maintainer considerations:**
-
-- This change prioritizes explicit configuration over convention
-- The migration path is straightforward but requires touching many files
-- Future primitive additions won't break existing code
-- The system is more robust for complex, real-world robotics applications
-
-### Real-World Application: Peng Quadrotor Framework
-
-The primitive-based system was battle-tested by porting [Peng](https://github.com/makeecat/Peng), a Rust-based minimal quadrotor autonomy framework, to work with dora. The dora-integrated version is available at [dora_quad](https://github.com/VertexStudio/dora_quad). The integration demonstrates:
-
-![Peng Quadrotor in Dora-Rerun](./docs/peng-dora.jpg)
-
-The visualization shows:
-
-- **3D Scene (left)**: Real-time quadrotor position, orientation, and trajectory with proper hierarchical entity paths
-- **Depth Camera (top right)**: Simulated depth sensor data for obstacle avoidance
-- **Telemetry (bottom)**: Time-series data including position, velocity, and orientation streams
-- **Control Signals**: Real-time visualization of motor commands and control loops
-
-This integration required the new primitive system to handle:
-
-- Multiple coordinate frames (world, body, camera)
-- Hierarchical sensor configurations
-- High-frequency telemetry data
-- Complex 3D visualizations with proper entity relationships
-
-Without the explicit primitive system, maintaining proper hierarchies and multiple sensor streams would have been challenging with the previous naming-convention-based approach.
-
-**Citation:**
-
-```bibtex
-@software{peng_quad,
-  author       = {Yang Zhou},
-  title        = {Peng: A Minimal Quadrotor Autonomy Framework in Rust},
-  year         = {2024},
-  publisher    = {GitHub},
-  journal      = {GitHub repository},
-  howpublished = {\url{https://github.com/makeecat/peng}},
-}
-```
-
-### Major Breaking Changes
-
-1. **Primitive-based Visualization System**
-
-   - **BREAKING**: All inputs now require a `primitive` metadata field to specify the visualization type
-   - Previously, visualization type was inferred from the input ID (e.g., "image", "depth", "boxes2d")
-   - Now you must explicitly specify: `metadata: { "primitive": "image" }` (or "depth", "boxes2d", etc.)
-   - This change allows more flexible naming of inputs and clearer intent
-
-2. **Rerun SDK Upgrade**
-
-   - Updated from Rerun v0.23.3 to v0.24.0
-   - Updated Python dependency from `rerun_sdk>=0.23.1` to `rerun_sdk>=0.24.0`
-
-3. **New 3D Boxes Support**
-
-   - Added comprehensive 3D bounding box visualization with multiple format support
-   - Supports three formats: "center_half_size" (default), "center_size", and "min_max"
-   - Configurable rendering: wireframe (default) or solid fill
-   - Support for per-box colors and labels
-
-4. **Enhanced Depth Visualization**
-
-   - Depth data now supports pinhole camera setup for proper 3D reconstruction
-   - Requires Float32Array format (previously supported Float64 and UInt16)
-   - New metadata fields for camera configuration:
-     - `camera_position`: [x, y, z] position
-     - `camera_orientation`: [x, y, z, w] quaternion
-     - `focal`: [fx, fy] focal lengths
-     - `principal_point`: [cx, cy] principal point (optional)
-   - Without camera metadata, depth is logged but 3D reconstruction is skipped
-
-5. **Removed Features**
-   - Removed legacy camera pitch configuration via CAMERA_PITCH environment variable
-   - Removed automatic depth-to-3D point cloud conversion without proper camera parameters
-
-### Migration Guide
-
-#### Before (old system):
+## Usage
 
 ```yaml
 nodes:
-  - id: rerun
+  - id: camera
+    path: opencv-video-capture
+    outputs:
+      - image
+  - id: dora-rerun
+    hub: dora-rerun@^1.0
     inputs:
-      image: camera/image # Type inferred from "image" in ID
-      depth: sensor/depth # Type inferred from "depth" in ID
-      boxes2d: detector/boxes2d # Type inferred from "boxes2d" in ID
+      image: camera/image
+    env:
+      OPERATING_MODE: SPAWN
 ```
 
-#### After (new system):
-
-```yaml
-nodes:
-  - id: rerun
-    inputs:
-      camera_feed: camera/image
-      depth_sensor: sensor/depth
-      detections: detector/boxes2d
-    # Visualization types must be specified in the sender's metadata:
-    # camera/image must send: metadata { "primitive": "image" }
-    # sensor/depth must send: metadata { "primitive": "depth" }
-    # detector/boxes2d must send: metadata { "primitive": "boxes2d" }
-```
-
-### Migration Status
-
-**Successfully tested examples:**
-
-- ✅ examples/rerun-viewer/dataflow.yml - Basic camera visualization
-- ✅ examples/camera/dataflow_rerun.yml - Camera with rerun
-- ✅ examples/python-dataflow/dataflow.yml - Camera + YOLO object detection
-- ✅ examples/python-multi-env/dataflow.yml - Multi-environment setup
-
-**Updated but NOT tested examples:**
-
-- 🔧 examples/keyboard/dataflow.yml - Updated dora-keyboard to send primitive metadata (requires Linux/X11 for testing)
-- 🔧 examples/translation/\* - Updated dora-distil-whisper and dora-argotranslate to send primitive metadata
-- 🔧 examples/reachy2-remote/dataflow_reachy.yml - Updated multiple nodes (dora-reachy2, dora-qwen2-5-vl, dora-sam2, parse_bbox.py, parse_whisper.py)
-- 🔧 examples/lebai/graphs/dataflow_full.yml - Updated dora-qwenvl, llama-factory-recorder, key_interpolation.py
-- 🔧 examples/av1-encoding/\* - Updated dora-dav1d and dora-rav1e to send primitive metadata
-
-Key changes made:
-
-1. Added `-e` flag to local package installs in dataflows for development
-2. Updated node packages to include `"primitive"` metadata:
-   - opencv-video-capture: adds `"primitive": "image"`
-   - dora-yolo: adds `"primitive": "boxes2d"`
-   - dora-keyboard: adds `"primitive": "text"`
-   - dora-distil-whisper: adds `"primitive": "text"`
-   - dora-argotranslate: adds `"primitive": "text"`
-   - dora-sam2: adds `"primitive": "masks"`
-   - dora-qwen2-5-vl: adds `"primitive": "text"`
-   - dora-qwenvl: adds `"primitive": "text"`
-   - dora-reachy2/camera.py: adds appropriate primitives
-   - dora-dav1d: adds `"primitive": "image"`
-   - dora-rav1e: adds `"primitive": "image"`
-
-## Getting Started
+## Build
 
 ```bash
-pip install dora-rerun
+cargo build --release --target-dir target
 ```
-
-## Adding to existing graph:
-
-```yaml
-- id: plot
-  build: pip install dora-rerun
-  path: dora-rerun
-  inputs:
-    image:
-      source: camera/image
-      queue_size: 1
-    text_qwenvl: dora-qwenvl/text
-    text_whisper: dora-distil-whisper/text
-  env:
-    IMAGE_WIDTH: 640
-    IMAGE_HEIGHT: 480
-    README: |
-      # Visualization
-    RERUN_MEMORY_LIMIT: 25%
-```
-
-## Supported Visualization Primitives
-
-All inputs require a `"primitive"` field in the metadata to specify the visualization type:
-
-### 1. image
-
-- **Data**: UInt8Array
-- **Required metadata**: `{ "primitive": "image", "width": int, "height": int, "encoding": str }`
-- **Supported encodings**: "bgr8", "rgb8", "jpeg", "png", "avif"
-
-### 2. depth
-
-- **Data**: Float32Array
-- **Required metadata**: `{ "primitive": "depth", "width": int, "height": int }`
-- **Optional metadata for 3D reconstruction**:
-  - `"camera_position"`: [x, y, z] position
-  - `"camera_orientation"`: [x, y, z, w] quaternion
-  - `"focal"`: [fx, fy] focal lengths
-  - `"principal_point"`: [cx, cy] principal point
-
-### 3. text
-
-- **Data**: StringArray
-- **Required metadata**: `{ "primitive": "text" }`
-
-### 4. boxes2d
-
-- **Data**: StructArray or Float32Array
-- **Required metadata**: `{ "primitive": "boxes2d", "format": str }`
-- **Formats**: "xyxy" (default), "xywh"
-
-### 5. boxes3d
-
-- **Data**: Float32Array or StructArray
-- **Required metadata**: `{ "primitive": "boxes3d" }`
-- **Optional metadata**:
-  - `"format"`: "center_half_size" (default), "center_size", "min_max"
-  - `"solid"`: bool (default false for wireframe)
-  - `"color"`: [r, g, b] RGB values 0-255
-
-### 6. masks
-
-- **Data**: UInt8Array
-- **Required metadata**: `{ "primitive": "masks", "width": int, "height": int }`
-
-### 7. jointstate
-
-- **Data**: Float32Array
-- **Required metadata**: `{ "primitive": "jointstate" }`
-- **Note**: Requires URDF configuration (see below)
-
-### 8. pose
-
-- **Data**: Float32Array (7 values: [x, y, z, qx, qy, qz, qw])
-- **Required metadata**: `{ "primitive": "pose" }`
-
-### 9. series
-
-- **Data**: Float32Array
-- **Required metadata**: `{ "primitive": "series" }`
-- **Note**: Currently logs only the first value as a scalar
-
-### 10. points3d
-
-- **Data**: Float32Array (xyz triplets)
-- **Required metadata**: `{ "primitive": "points3d" }`
-- **Optional metadata**:
-  - `"color"`: [r, g, b] RGB values 0-255
-  - `"radii"`: list of float radius values
-
-### 11. points2d
-
-- **Data**: Float32Array (xy pairs)
-- **Required metadata**: `{ "primitive": "points2d" }`
-
-### 12. lines3d
-
-- **Data**: Float32Array (xyz triplets defining line segments)
-- **Required metadata**: `{ "primitive": "lines3d" }`
-- **Optional metadata**:
-  - `"color"`: [r, g, b] RGB values 0-255
-  - `"radius"`: float line thickness
-
-## (Experimental) For plotting 3D URDF
-
-```bash
-pip install git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git
-```
-
-Make sure to name the dataflow as follows:
-
-```yaml
-- id: rerun
-  path: dora-rerun
-  inputs:
-    jointstate_<ENTITY_NAME>: <ENTITY_NAME>/jointstate
-  env:
-    <ENTITY_NAME>_urdf: /path/to/<ENTITY_NAME>.urdf
-    <ENTITY_NAME>_transform: 0 0.3 0
-```
-
-> [!IMPORTANT]  
-> Make sure that the urdf file name correspond to your dataflow object name otherwise, it will not be able to link to the corresponding entity.
-
-> [!WARNING]
-> Please make sure to review the following gotchas:
->
-> - Filename included in URDF are going to be relative to your dataflow working directory instead of the URDF path: https://github.com/rerun-io/rerun-loader-python-example-urdf/issues/13
-> - URDF loader is not on pip and so you need to install it yourself https://github.com/rerun-io/rerun-loader-python-example-urdf/issues/12
-> - There is no warning if a file is not logged properly. https://github.com/rerun-io/rerun-loader-python-example-urdf/pull/14
-> - There is no transparent color in rerun. https://github.com/rerun-io/rerun/issues/1611
-
-## Configurations
-
-- RERUN_MEMORY_LIMIT: Rerun memory limit
-
-## Reference documentation
-
-- dora-rerun
-  - github: https://github.com/dora-rs/dora-hub/blob/main/node-hub/dora-rerun
-- rerun
-  - github: https://github.com/rerun-io/rerun
-  - website: https://rerun.io
-
-## Examples
-
-- speech to text
-  - github: https://github.com/dora-rs/dora-hub/blob/main/examples/speech-to-text
-- vision language model
-  - github: https://github.com/dora-rs/dora-hub/blob/main/examples/vlm
-
-## License
-
-The code and model weights are released under the MIT License.

--- a/node-hub/dora-rerun/README.md
+++ b/node-hub/dora-rerun/README.md
@@ -22,8 +22,7 @@ metadata parameter, and if absent infers one from a keyword contained in the
 input id (e.g. an id containing `image`). An id containing more than one keyword,
 or an unknown primitive, is an error. The supported primitives are: `image`,
 `depth`, `text`, `boxes2d`, `boxes3d`, `masks`, `jointstate`, `pose`, `series`,
-`points3d`, `points2d`, and `lines3d` (the last is selectable only via the
-`primitive` metadata parameter).
+`points3d`, `points2d`, and `lines3d`.
 
 Some primitives read extra per-message metadata parameters — for example
 `width`/`height`/`encoding` for `image` and `depth`, `format` for `boxes2d`/
@@ -73,7 +72,7 @@ nodes:
     outputs:
       - image
   - id: dora-rerun
-    hub: dora-rerun@^1.0
+    hub: dora-rerun@^0.5
     inputs:
       image: camera/image
     env:

--- a/node-hub/dora-rerun/dora-node.yml
+++ b/node-hub/dora-rerun/dora-node.yml
@@ -1,0 +1,77 @@
+apiVersion: 1
+name: dora-rerun
+namespace: dora-rs
+description: Log images, depth, boxes, points, series, text, and URDF robot state to a Rerun.io viewer.
+categories: [visualization, debug]
+keywords: [rerun, visualization, viewer, image, robot]
+runtime: rust
+entrypoint: target/release/dora-rerun
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+inputs:
+  image:
+    description: RGB/BGR or encoded (jpeg/png/avif) image bytes; uses width/height/encoding metadata.
+    required: false
+  depth:
+    description: Float32/Float64/UInt16 depth map; logged as a DepthImage when camera metadata (camera_position, camera_orientation, focal) is present.
+    required: false
+  text:
+    description: UTF-8 string array logged as a TextLog (Chinese characters are transliterated to pinyin).
+    required: false
+  boxes2d:
+    description: 2D bounding boxes (struct with bbox/labels or a float/int array); uses format metadata (xyxy/xywh).
+    required: false
+  boxes3d:
+    description: 3D bounding boxes (struct or float/int array); uses format metadata (min_max/center_size/center_half_size), optional color/solid.
+    required: false
+  masks:
+    description: Float32 or boolean mask array cached for later painting.
+    required: false
+  jointstate:
+    description: Joint positions (float array) applied to a loaded URDF chain matched by the input id suffix.
+    required: false
+  pose:
+    description: Joint positions (float array) applied to a loaded URDF chain matched by the input id suffix.
+    required: false
+  series:
+    description: Float64 array logged as scalar time series, one entity per index.
+    required: false
+  points3d:
+    description: Flat float array of 3D points (xyz triples); uses color/radii metadata.
+    required: false
+  points2d:
+    description: Flat float array of 2D points (xy pairs); color assigned per input id.
+    required: false
+  lines3d:
+    description: Flat float array of 3D line-strip points (xyz triples); uses color/radius metadata.
+    required: false
+outputs: {}
+env:
+  OPERATING_MODE:
+    type: string
+    default: "SPAWN"
+    description: Viewer mode — SPAWN (launch viewer), CONNECT (gRPC to a running viewer), or SAVE (write a .rerun archive). Unknown values fall back to SPAWN.
+  RERUN_SERVER_ADDR:
+    type: string
+    default: "127.0.0.1:9876"
+    description: gRPC address of the Rerun viewer to connect to when OPERATING_MODE is CONNECT.
+  RERUN_MEMORY_LIMIT:
+    type: string
+    default: "25%"
+    description: Rerun viewer memory limit (e.g. "25%" or "4GB") used in SPAWN mode.
+  README:
+    type: string
+    description: Optional Markdown text logged as a README TextDocument in the viewer.
+example: |
+  nodes:
+    - id: camera
+      path: opencv-video-capture
+      outputs:
+        - image
+    - id: dora-rerun
+      hub: dora-rerun@^1.0
+      inputs:
+        image: camera/image
+      env:
+        OPERATING_MODE: SPAWN

--- a/node-hub/dora-rerun/dora-node.yml
+++ b/node-hub/dora-rerun/dora-node.yml
@@ -70,7 +70,7 @@ example: |
       outputs:
         - image
     - id: dora-rerun
-      hub: dora-rerun@^1.0
+      hub: dora-rerun@^0.5
       inputs:
         image: camera/image
       env:

--- a/node-hub/dora-rerun/src/lib.rs
+++ b/node-hub/dora-rerun/src/lib.rs
@@ -123,6 +123,7 @@ pub fn lib_main() -> Result<()> {
                     "series",
                     "points3d",
                     "points2d",
+                    "lines3d",
                 ];
                 let matches: Vec<&str> = keywords
                     .iter()
@@ -160,6 +161,8 @@ pub fn lib_main() -> Result<()> {
                     Some("points3d")
                 } else if id_str.contains("points2d") {
                     Some("points2d")
+                } else if id_str.contains("lines3d") {
+                    Some("lines3d")
                 } else {
                     None
                 };
@@ -171,7 +174,7 @@ pub fn lib_main() -> Result<()> {
                     bail!(
                         "No visualization primitive specified in metadata for input '{}'. \
                         Please add 'primitive: <type>' to metadata, where <type> is one of: \
-                        image, depth, text, boxes2d, boxes3d, masks, jointstate, pose, series, points3d, points2d",
+                        image, depth, text, boxes2d, boxes3d, masks, jointstate, pose, series, points3d, points2d, lines3d",
                         id
                     );
                 }

--- a/node-hub/dora-rustypot/README.md
+++ b/node-hub/dora-rustypot/README.md
@@ -1,0 +1,56 @@
+# dora-rustypot
+
+Servo/motor bus control over a serial port using the [rustypot](https://crates.io/crates/rustypot) library. Drives Feetech STS3215 servos (protocol v1): writes goal positions from a `pose` input and reads back present positions on `tick`.
+
+## Behavior
+
+On startup the node opens the serial port named by `PORT` at `BAUDRATE`, builds an STS3215 controller (protocol v1), and configures torque for the servos listed in `IDS`:
+
+- If `TORQUE` is set, torque is enabled on every servo; if its value parses as an integer it is also applied as a torque limit.
+- If `TORQUE` is unset, torque is disabled.
+
+It then processes input events:
+
+- On a `tick` input, it reads the present position of every configured servo and emits them as the `pose` output (with `encoding=jointstate` metadata).
+- On a `pose` input, it casts the data to a vector of `f64` (one value per id) and writes them as goal positions.
+- Any other input id is logged to stderr and ignored.
+
+## Inputs
+
+- `tick`: on any value, triggers a present-position read that is emitted as `pose`.
+- `pose`: goal positions to write, a vector of `f64` (one per id, in `IDS` order).
+
+## Outputs
+
+- `pose`: present joint positions read from the servos, carrying an `encoding=jointstate` metadata parameter.
+
+## Environment variables
+
+- `PORT` (required): serial port device name, e.g. `/dev/ttyUSB0`.
+- `BAUDRATE` (default `1000000`): serial baud rate.
+- `IDS` (default `1,2,3,4,5,6`): comma/space-separated servo ids.
+- `TORQUE` (optional): if set, enables torque on all servos; an integer value is also applied as a torque limit. Unset disables torque.
+
+## Usage
+
+```yaml
+nodes:
+  - id: dora-rustypot
+    build: cargo build --release --target-dir target
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/20
+      pose: planner/goal_position
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyUSB0
+      BAUDRATE: "1000000"
+      IDS: "1,2,3,4,5,6"
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/dora-rustypot/README.md
+++ b/node-hub/dora-rustypot/README.md
@@ -36,8 +36,7 @@ It then processes input events:
 ```yaml
 nodes:
   - id: dora-rustypot
-    build: cargo build --release --target-dir target
-    path: dora-rustypot
+    hub: dora-rustypot@^0.1
     inputs:
       tick: dora/timer/millis/20
       pose: planner/goal_position

--- a/node-hub/dora-rustypot/dora-node.yml
+++ b/node-hub/dora-rustypot/dora-node.yml
@@ -1,0 +1,51 @@
+apiVersion: 1
+name: dora-rustypot
+namespace: dora-rs
+description: Servo/motor bus control over serial via the rustypot library (Feetech STS3215, protocol v1). Writes goal positions from a `pose` input and reads present positions on `tick`, emitting them as a `pose` output.
+categories: [actuator, robot]
+keywords: [servo, motor, feetech, sts3215, serial, rustypot]
+runtime: rust
+entrypoint: target/release/dora-rustypot
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  tick:
+    description: On any value, reads the present position of every configured servo and emits it as the `pose` output.
+  pose:
+    description: Goal positions to write to the servos, as a vector of f64 (one per configured id, in the order of IDS).
+
+outputs:
+  pose:
+    description: Present joint positions read from the servos. Carries an `encoding=jointstate` metadata parameter.
+
+env:
+  PORT:
+    type: string
+    description: Serial port device name the servo bus is connected to (required, e.g. /dev/ttyUSB0).
+  BAUDRATE:
+    type: int
+    default: 1000000
+    description: Serial baud rate.
+  IDS:
+    type: string
+    default: "1,2,3,4,5,6"
+    description: Comma/space-separated servo ids to control.
+  TORQUE:
+    type: int
+    description: If set, enables torque on all servos; if the value parses as an integer it is also applied as a torque limit. If unset, torque is disabled at startup.
+
+example: |
+  - id: dora-rustypot
+    build: cargo build --release --target-dir target
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/20
+      pose: planner/goal_position
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyUSB0
+      BAUDRATE: "1000000"
+      IDS: "1,2,3,4,5,6"

--- a/node-hub/dora-rustypot/dora-node.yml
+++ b/node-hub/dora-rustypot/dora-node.yml
@@ -38,8 +38,7 @@ env:
 
 example: |
   - id: dora-rustypot
-    build: cargo build --release --target-dir target
-    path: dora-rustypot
+    hub: dora-rustypot@^0.1
     inputs:
       tick: dora/timer/millis/20
       pose: planner/goal_position

--- a/node-hub/openai-proxy-server/README.md
+++ b/node-hub/openai-proxy-server/README.md
@@ -49,8 +49,7 @@ model's `text` output feeds back into this server:
 ```yaml
 nodes:
   - id: openai-proxy-server
-    build: cargo build --release --target-dir target
-    path: dora-openai-proxy-server
+    hub: dora-openai-proxy-server@^0.5
     inputs:
       text: model-node/text
     outputs:

--- a/node-hub/openai-proxy-server/README.md
+++ b/node-hub/openai-proxy-server/README.md
@@ -1,0 +1,71 @@
+# dora-openai-proxy-server
+
+An OpenAI-compatible HTTP proxy server that bridges a dora dataflow with
+OpenAI-style chat-completion requests.
+
+## Behavior
+
+On startup the node binds an HTTP server on `0.0.0.0:8000` and connects as a
+dora node. It exposes an OpenAI-style API:
+
+- `POST /v1/chat/completions` — parses the incoming `ChatCompletionRequest`,
+  flattens its messages into a list of prompt strings, and emits them on the
+  `text` output. The HTTP request is held open and queued.
+- `GET /v1/models` — returns a single static `custom model` entry owned by
+  `dora`.
+- `/echo` — returns `echo test`.
+- Any other path — serves a static file from the `chatbot-ui` directory
+  (falling back to `404.html`).
+
+When the dataflow replies on the `text` input, the node pops the oldest queued
+request, joins the received string array with newlines, wraps it in a
+`chat.completion` object, and returns it as the HTTP response (supports both
+streaming and non-streaming modes). Requests and replies are matched in FIFO
+order.
+
+The HTTP port (`8000`), bind address (`0.0.0.0`), and web-UI directory
+(`chatbot-ui`) are hardcoded.
+
+## Inputs
+
+- `text`: the completion text to return to the pending HTTP chat request. A
+  UTF-8 string array; its elements are joined with newlines and used as the
+  assistant message of the next queued chat-completion response.
+
+## Outputs
+
+- `text`: the flattened prompt texts extracted from an incoming chat-completion
+  request (one string per message), emitted on each `POST /v1/chat/completions`.
+
+## Environment variables
+
+None.
+
+## Usage
+
+Wire a model node so that this server's `text` output feeds the model and the
+model's `text` output feeds back into this server:
+
+```yaml
+nodes:
+  - id: openai-proxy-server
+    build: cargo build --release --target-dir target
+    path: dora-openai-proxy-server
+    inputs:
+      text: model-node/text
+    outputs:
+      - text
+
+  - id: model-node
+    path: model-node
+    inputs:
+      text: openai-proxy-server/text
+    outputs:
+      - text
+```
+
+## Build
+
+```bash
+cargo build --release --target-dir target
+```

--- a/node-hub/openai-proxy-server/dora-node.yml
+++ b/node-hub/openai-proxy-server/dora-node.yml
@@ -1,0 +1,40 @@
+apiVersion: 1
+name: dora-openai-proxy-server
+namespace: dora-rs
+description: >-
+  OpenAI-compatible HTTP proxy server that bridges a dora dataflow with
+  OpenAI-style chat-completion requests. Serves an HTTP API on 0.0.0.0:8000,
+  forwards each incoming chat request into the dataflow as a `text` output, and
+  returns the `text` input it receives back as the chat-completion response.
+categories: [llm, communication]
+keywords: [openai, proxy, http, chat-completion, server, bridge]
+runtime: rust
+entrypoint: target/release/dora-openai-proxy-server
+build: cargo build --release --target-dir target
+dora: ">=0.3.9"
+platforms: []
+
+inputs:
+  text:
+    description: >-
+      The completion text to return to the pending HTTP chat request. A UTF-8
+      string array; its elements are joined with newlines and sent back as the
+      assistant message of the next queued chat-completion response.
+
+outputs:
+  text:
+    description: >-
+      The flattened prompt texts extracted from an incoming OpenAI
+      chat-completion request (one string per message), emitted whenever an HTTP
+      client posts to `/v1/chat/completions`.
+
+env: {}
+
+example: |
+  - id: openai-proxy-server
+    build: cargo build --release --target-dir target
+    path: dora-openai-proxy-server
+    inputs:
+      text: model-node/text
+    outputs:
+      - text

--- a/node-hub/openai-proxy-server/dora-node.yml
+++ b/node-hub/openai-proxy-server/dora-node.yml
@@ -32,8 +32,7 @@ env: {}
 
 example: |
   - id: openai-proxy-server
-    build: cargo build --release --target-dir target
-    path: dora-openai-proxy-server
+    hub: dora-openai-proxy-server@^0.5
     inputs:
       text: model-node/text
     outputs:


### PR DESCRIPTION
Migrates the final batch of node-hub nodes — the 13 Rust/hybrid nodes — to the Hub manifest format, completing the per-node migration started in #76.

## Nodes (13)
`dora-rerun`, `dora-record`, `dora-rustypot`, `dora-rav1e`, `dora-dav1d`, `dora-kit-car`, `dora-object-to-pose`, `dora-openai-websocket`, `dora-mcp-server`, `dora-mcp-host`, `dora-mistral-rs`, `dora-qwen-omni`, `openai-proxy-server`.

Each gets a `dora-node.yml` typed contract + a normalized `README.md` (Title / Behavior / Inputs / Outputs / Environment variables / Usage / Build).

## Conventions applied
- `runtime: rust`, `entrypoint: target/release/<bin>`, `build: cargo build --release --target-dir target`.
- `name` = Cargo `[package].name` (note `openai-proxy-server`'s dir differs from its bin `dora-openai-proxy-server`).
- Inputs/outputs/env derived strictly from each crate's `src/` (Event::Input ids, `send_output`, `std::env::var`). No invented fields.
- All 13 already use `DoraNode::init_from_env()` — Hub-spawnable as-is, no `init_flexible` change needed.
- Every manifest passes `dora validate --node-manifest`.

## Node bug fixed (one-liner)
`dora-rerun`: the `lines3d` primitive was reachable only via explicit `primitive: lines3d` metadata — the topic-id inference path (keyword list + if-chain) and the "no primitive specified" error message both omitted it, even though the dispatch `match` handled it. Added `lines3d` to all three spots. `cargo fmt --check` and `cargo check -p dora-rerun` pass.

## Flagged for follow-up (not fixed here — bigger than a one-liner)
- `dora-qwen-omni`: configured entirely via clap CLI args (`--model`, `--mmproj`, `--prompt`), no env vars — so it can't be used via a plain `hub:` reference without `args:`. Manifest has empty `env` and the example uses `path:` + `args:`.
- Catch-all/config-driven port nodes (`dora-record`, `dora-dav1d`, `dora-kit-car`, `dora-mcp-host`, `dora-mcp-server`) re-emit under runtime/config-driven ids; manifests declare a representative `data`/`tick` port and document the dynamic behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
