### PR TITLE
feat(index-ci): periodic reachability + integrity audits (P3.4, #64)

### DIFF
--- a/.github/workflows/node-index-audit.yml
+++ b/.github/workflows/node-index-audit.yml
@@ -1,0 +1,37 @@
+name: node-index audit
+
+# Periodic hardening of the catalog (Hub spec P3.4, §7.5/§11). Unlike
+# node-index-ci.yml — which gates PRs on diff-scoped rules — these checks need
+# the populated catalog and ongoing operation, so they run on a schedule:
+#   * reachability    — every pinned source still fetches
+#   * integrity-audit — entries still match the manifest at their pinned commit
+# They no-op cleanly while the catalog is empty (both exit 0 on zero entries),
+# so this is safe to land before the catalog is bootstrapped. A red run is a
+# maintainer signal; these jobs never gate the human-reviewed node-hub/ path.
+on:
+  schedule:
+    - cron: '17 6 * * 1' # weekly, Mondays 06:17 UTC
+  workflow_dispatch:
+# Schedule + manual only — not on PRs. These checks fetch every pinned source
+# over the network; gating PRs on them would be slow and flaky once the catalog
+# grows. The tooling itself is regression-tested on PRs by node-index-ci.yml's
+# `cargo test -p dora-index-ci` step (the audit-e2e tests use local repos).
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: index-ci
+      - name: Build the gate
+        run: cargo build -p dora-index-ci --release
+      - name: Pin reachability re-check
+        run: ./target/release/dora-index-ci reachability
+      - name: Integrity spot-audit (manifest vs pinned source)
+        run: ./target/release/dora-index-ci integrity-audit

--- a/index-ci/Cargo.toml
+++ b/index-ci/Cargo.toml
@@ -18,6 +18,8 @@ eyre = "0.6"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.33"
+# used at runtime by the audit subcommands to fetch pinned sources into scratch repos
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/index-ci/src/catalog.rs
+++ b/index-ci/src/catalog.rs
@@ -1,0 +1,113 @@
+//! Shared catalog walk for the audit subcommands (`reachability`,
+//! `integrity-audit`). Collects the *parseable* version entries
+//! (`node-index/<ns>/<name>/<semver>.yml`); `package.yml`, symlinks, and
+//! non-version files are skipped, and an unparseable entry is reported as a
+//! `::warning::` and skipped — the `validate` subcommand is the gate that fails
+//! a PR on a malformed entry, so the periodic audits only re-check entries that
+//! already passed it.
+
+use std::path::{Path, PathBuf};
+
+use crate::model::IndexEntry;
+
+/// A parsed published version entry plus its catalog-relative path for reporting.
+pub struct CatalogEntry {
+    pub rel: String,
+    pub entry: IndexEntry,
+}
+
+/// Collect the parseable version entries under `root` (the `node-index/` dir).
+pub fn version_entries(root: &Path) -> eyre::Result<Vec<CatalogEntry>> {
+    let mut files = Vec::new();
+    collect(root, &mut files)?;
+    let mut out = Vec::new();
+    for path in files {
+        let parts: Vec<String> = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        // only node-index/<ns>/<name>/<file>.yml version entries
+        if parts.len() != 3 || parts[2] == "package.yml" {
+            continue;
+        }
+        let rel = parts.join("/");
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) => {
+                println!("::warning::{rel}: cannot read: {e}");
+                continue;
+            }
+        };
+        match IndexEntry::parse(&raw) {
+            Ok(entry) => out.push(CatalogEntry { rel, entry }),
+            Err(e) => println!("::warning::{rel}: skipped (invalid entry: {e})"),
+        }
+    }
+    Ok(out)
+}
+
+/// Recursively collect regular `*.yml` files under `dir`. Symlinks are not
+/// followed and not returned (the `validate` subcommand rejects them); a missing
+/// directory yields an empty list so the audits no-op on an unpopulated catalog.
+fn collect(dir: &Path, out: &mut Vec<PathBuf>) -> eyre::Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let meta = std::fs::symlink_metadata(&path)?;
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            collect(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("yml") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    const ENTRY: &str = "manifest:\n  apiVersion: 1\n  name: n\n  namespace: acme\n  \
+        runtime: rust\n  entrypoint: e\nsource:\n  git: https://example.com/r.git\n  \
+        rev: 0000000000000000000000000000000000000000\n";
+
+    #[test]
+    fn collects_version_entries_and_skips_package_and_bad_files() {
+        let root = tempfile::tempdir().unwrap();
+        let p = root.path();
+        write(&p.join("acme/n/1.0.0.yml"), ENTRY);
+        write(&p.join("acme/n/package.yml"), "owners: [acme]\n");
+        write(&p.join("acme/n/2.0.0.yml"), "manifest: {oops\n"); // unparseable → skipped
+        write(&p.join("acme/loose.yml"), ENTRY); // wrong depth → skipped
+
+        let entries = version_entries(p).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].rel, "acme/n/1.0.0.yml");
+    }
+
+    #[test]
+    fn empty_catalog_yields_no_entries() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(version_entries(root.path()).unwrap().is_empty());
+        // a never-created node-index dir also no-ops (the scheduled audit case)
+        assert!(
+            version_entries(&root.path().join("missing"))
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/index-ci/src/catalog.rs
+++ b/index-ci/src/catalog.rs
@@ -1,7 +1,7 @@
 //! Shared catalog walk for the audit subcommands (`reachability`,
 //! `integrity-audit`). Collects the *parseable* version entries
 //! (`node-index/<ns>/<name>/<semver>.yml`); `package.yml`, symlinks, and
-//! non-version files are skipped, and an unparseable entry is reported as a
+//! non-version files are skipped, and an unparsable entry is reported as a
 //! `::warning::` and skipped — the `validate` subcommand is the gate that fails
 //! a PR on a malformed entry, so the periodic audits only re-check entries that
 //! already passed it.
@@ -91,7 +91,7 @@ mod tests {
         let p = root.path();
         write(&p.join("acme/n/1.0.0.yml"), ENTRY);
         write(&p.join("acme/n/package.yml"), "owners: [acme]\n");
-        write(&p.join("acme/n/2.0.0.yml"), "manifest: {oops\n"); // unparseable → skipped
+        write(&p.join("acme/n/2.0.0.yml"), "manifest: {oops\n"); // unparsable → skipped
         write(&p.join("acme/loose.yml"), ENTRY); // wrong depth → skipped
 
         let entries = version_entries(p).unwrap();

--- a/index-ci/src/git.rs
+++ b/index-ci/src/git.rs
@@ -1,8 +1,9 @@
 //! Thin wrappers over the `git` CLI, run in the current working directory.
 
+use std::path::Path;
 use std::process::Command;
 
-use eyre::{Context, bail};
+use eyre::{Context, ContextCompat, bail};
 
 /// Run `git <args>` and return stdout, erroring on a non-zero exit.
 pub fn git(args: &[&str]) -> eyre::Result<String> {
@@ -68,6 +69,44 @@ pub fn show(reference: &str, path: &str) -> eyre::Result<Option<String>> {
     }
 }
 
+/// Shallow-fetch a single commit into a throwaway repo so the audit subcommands
+/// can re-check reachability and inspect committed files. Errors if the remote
+/// or that exact `rev` is unreachable (a deleted repo, a force-pushed-away
+/// commit, a rotted source).
+///
+/// Self-guards against argument injection before shelling out: `url` must not
+/// start with `-` (so `git` can't read it as an option) and `rev` must be a hex
+/// object id. Callers pass entries the `validate` subcommand already accepted;
+/// this is a belt-and-suspenders second check.
+pub fn shallow_fetch(url: &str, rev: &str) -> eyre::Result<tempfile::TempDir> {
+    if url.is_empty() || url.starts_with('-') || url.contains(|c: char| c.is_control()) {
+        bail!("refusing to fetch suspicious url `{url}`");
+    }
+    if rev.is_empty() || !rev.chars().all(|c| c.is_ascii_hexdigit()) {
+        bail!("refusing to fetch non-hex rev `{rev}`");
+    }
+    let dir = tempfile::tempdir().context("failed to create temp dir for fetch")?;
+    let path = dir.path().to_str().context("temp dir path is not UTF-8")?;
+    git(&["-C", path, "init", "-q"])?;
+    git(&["-C", path, "fetch", "--depth", "1", "-q", url, rev])
+        .with_context(|| format!("`{url}` @ {} is unreachable", &rev[..rev.len().min(12)]))?;
+    Ok(dir)
+}
+
+/// Contents of `<rev>:<path>` inside an already-fetched repo `dir`, or `None` if
+/// that path doesn't exist at the rev.
+pub fn show_in(dir: &Path, rev: &str, path: &str) -> eyre::Result<Option<String>> {
+    let repo = dir.to_str().context("repo path is not UTF-8")?;
+    let out = Command::new("git")
+        .args(["-C", repo, "show", &format!("{rev}:{path}")])
+        .output()
+        .context("failed to run `git show`")?;
+    Ok(out
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned()))
+}
+
 /// Namespaces present under `node-index/` at `<ref>` (dirs with a package.yml).
 pub fn namespaces_at(reference: &str) -> eyre::Result<std::collections::BTreeSet<String>> {
     let out = git(&["ls-tree", "-r", "--name-only", reference, "node-index/"])?;
@@ -80,4 +119,21 @@ pub fn namespaces_at(reference: &str) -> eyre::Result<std::collections::BTreeSet
         }
     }
     Ok(namespaces)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The fetch+show happy path is exercised end-to-end against a real local
+    // repo in `tests/audit-e2e.rs`; here we only pin the cheap injection guards
+    // that must reject before any `git` process is spawned.
+    #[test]
+    fn shallow_fetch_rejects_option_shaped_urls_and_non_hex_revs() {
+        let hex = "a".repeat(40);
+        assert!(shallow_fetch("--upload-pack=touch pwned", &hex).is_err());
+        assert!(shallow_fetch("", &hex).is_err());
+        assert!(shallow_fetch("https://example.com/r.git", "not-hex").is_err());
+        assert!(shallow_fetch("https://example.com/r.git", "").is_err());
+    }
 }

--- a/index-ci/src/integrity.rs
+++ b/index-ci/src/integrity.rs
@@ -1,0 +1,168 @@
+//! Integrity spot-audit (spec P3.4, §7.5/§11): for a sample of catalog entries,
+//! re-fetch the pinned source and confirm the manifest committed at that exact
+//! `rev` still matches the entry's stored manifest snapshot.
+//!
+//! This complements the append-only rule: append-only stops a *published version
+//! file* from being edited in place; this catches an entry whose manifest was
+//! rewritten to disagree with what is actually committed at the pinned commit
+//! (e.g. a published entry pointing at a benign commit but claiming a different
+//! `entrypoint`/`runtime`).
+//!
+//! The entry format stores the manifest snapshot, not a content digest, so the
+//! audit compares the manifest *envelope* — the trust-bearing, always-present
+//! fields the resolver and `validate` rely on (`apiVersion`, `name`,
+//! `namespace`, `runtime`, `entrypoint`) — rather than hashing the opaque
+//! manifest body, which would false-positive on serde round-trip differences.
+
+use std::path::Path;
+
+use crate::model::Manifest;
+use crate::{catalog, git};
+
+/// The node manifest filename in a source repo (mirrors dora-core's
+/// `manifest::MANIFEST_FILENAME`; `dora hub publish` reads `<subdir>/dora-node.yml`).
+const MANIFEST_FILENAME: &str = "dora-node.yml";
+
+/// `sample`: audit only the first N entries in sorted order (a cheap spot-check),
+/// or `None` to audit the whole catalog.
+pub fn run(root: &Path, sample: Option<usize>) -> eyre::Result<i32> {
+    let mut entries = catalog::version_entries(root)?;
+    entries.sort_by(|a, b| a.rel.cmp(&b.rel)); // deterministic order / sample
+    if let Some(n) = sample {
+        entries.truncate(n);
+    }
+
+    let mut checked = 0usize;
+    let mut drift: Vec<String> = Vec::new();
+
+    for ce in &entries {
+        if ce.entry.yanked {
+            continue;
+        }
+        let (git_url, rev) = match (&ce.entry.source.git, &ce.entry.source.rev) {
+            (Some(g), Some(r)) => (g, r),
+            _ => continue, // binary-only: no source manifest to compare against
+        };
+        let manifest_path = match &ce.entry.source.subdir {
+            Some(s) => format!("{s}/{MANIFEST_FILENAME}"),
+            None => MANIFEST_FILENAME.to_owned(),
+        };
+        checked += 1;
+        let dir = match git::shallow_fetch(git_url, rev) {
+            Ok(dir) => dir,
+            Err(e) => {
+                drift.push(format!("{}: source unreachable: {e:#}", ce.rel));
+                continue;
+            }
+        };
+        let committed = match git::show_in(dir.path(), rev, &manifest_path)? {
+            Some(committed) => committed,
+            None => {
+                drift.push(format!(
+                    "{}: {manifest_path} absent at pinned commit",
+                    ce.rel
+                ));
+                continue;
+            }
+        };
+        let actual: Manifest = match serde_yaml::from_str(&committed) {
+            Ok(actual) => actual,
+            Err(e) => {
+                drift.push(format!(
+                    "{}: committed {MANIFEST_FILENAME} is unparseable: {e}",
+                    ce.rel
+                ));
+                continue;
+            }
+        };
+        if let Some(reason) = envelope_drift(&ce.entry.manifest, &actual) {
+            drift.push(format!("{}: {reason}", ce.rel));
+        }
+    }
+
+    for d in &drift {
+        println!("::error::{d}");
+    }
+
+    if checked == 0 {
+        println!("integrity-audit: OK (no git-pinned entries to audit)");
+        return Ok(0);
+    }
+    if drift.is_empty() {
+        println!("integrity-audit: OK ({checked} entr(ies) match their pinned source)");
+        Ok(0)
+    } else {
+        println!(
+            "integrity-audit: {} of {checked} entr(ies) DRIFTED from source",
+            drift.len()
+        );
+        Ok(1)
+    }
+}
+
+/// First mismatch between the stored manifest snapshot and the manifest actually
+/// committed at the pinned `rev`, or `None` if the envelope matches.
+fn envelope_drift(stored: &Manifest, actual: &Manifest) -> Option<String> {
+    if stored.api_version != actual.api_version {
+        return Some(format!(
+            "apiVersion drift: entry says {}, source has {}",
+            stored.api_version, actual.api_version
+        ));
+    }
+    if stored.name != actual.name {
+        return Some(format!(
+            "name drift: entry says `{}`, source has `{}`",
+            stored.name, actual.name
+        ));
+    }
+    if stored.namespace != actual.namespace {
+        return Some(format!(
+            "namespace drift: entry says `{}`, source has `{}`",
+            stored.namespace, actual.namespace
+        ));
+    }
+    if stored.runtime != actual.runtime {
+        return Some(format!(
+            "runtime drift: entry says `{}`, source has `{}`",
+            stored.runtime, actual.runtime
+        ));
+    }
+    if stored.entrypoint != actual.entrypoint {
+        return Some(format!(
+            "entrypoint drift: entry says `{}`, source has `{}`",
+            stored.entrypoint, actual.entrypoint
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(yaml: &str) -> Manifest {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    const BASE: &str = "apiVersion: 1\nname: a\nnamespace: ns\nruntime: rust\nentrypoint: e\n";
+
+    #[test]
+    fn detects_envelope_field_drift() {
+        let stored = manifest(BASE);
+        let drifted =
+            manifest("apiVersion: 1\nname: b\nnamespace: ns\nruntime: rust\nentrypoint: e\n");
+        assert!(
+            envelope_drift(&stored, &drifted)
+                .unwrap()
+                .contains("name drift")
+        );
+    }
+
+    #[test]
+    fn ignores_opaque_body_differences() {
+        // same envelope, different opaque body (`description`) → not drift
+        let stored = manifest(&format!("{BASE}description: one\n"));
+        let actual = manifest(&format!("{BASE}description: two\n"));
+        assert!(envelope_drift(&stored, &actual).is_none());
+    }
+}

--- a/index-ci/src/integrity.rs
+++ b/index-ci/src/integrity.rs
@@ -16,7 +16,7 @@
 
 use std::path::Path;
 
-use crate::model::Manifest;
+use crate::model::{Manifest, git_pins};
 use crate::{catalog, git};
 
 /// The node manifest filename in a source repo (mirrors dora-core's
@@ -39,44 +39,41 @@ pub fn run(root: &Path, sample: Option<usize>) -> eyre::Result<i32> {
         if ce.entry.yanked {
             continue;
         }
-        let (git_url, rev) = match (&ce.entry.source.git, &ce.entry.source.rev) {
-            (Some(g), Some(r)) => (g, r),
-            _ => continue, // binary-only: no source manifest to compare against
-        };
-        let manifest_path = match &ce.entry.source.subdir {
-            Some(s) => format!("{s}/{MANIFEST_FILENAME}"),
-            None => MANIFEST_FILENAME.to_owned(),
-        };
-        checked += 1;
-        let dir = match git::shallow_fetch(git_url, rev) {
-            Ok(dir) => dir,
-            Err(e) => {
-                drift.push(format!("{}: source unreachable: {e:#}", ce.rel));
-                continue;
+        // audit every git-pinned level — primary *and* each `fallback-git`,
+        // which hosts the same node and must match the stored manifest too
+        for pin in git_pins(&ce.entry.source) {
+            let site = crate::audit_site(&ce.rel, pin.depth);
+            let manifest_path = match pin.subdir {
+                Some(s) => format!("{s}/{MANIFEST_FILENAME}"),
+                None => MANIFEST_FILENAME.to_owned(),
+            };
+            checked += 1;
+            let dir = match git::shallow_fetch(pin.git, pin.rev) {
+                Ok(dir) => dir,
+                Err(e) => {
+                    drift.push(format!("{site}: source unreachable: {e:#}"));
+                    continue;
+                }
+            };
+            let committed = match git::show_in(dir.path(), pin.rev, &manifest_path)? {
+                Some(committed) => committed,
+                None => {
+                    drift.push(format!("{site}: {manifest_path} absent at pinned commit"));
+                    continue;
+                }
+            };
+            let actual: Manifest = match serde_yaml::from_str(&committed) {
+                Ok(actual) => actual,
+                Err(e) => {
+                    drift.push(format!(
+                        "{site}: committed {MANIFEST_FILENAME} is unparseable: {e}"
+                    ));
+                    continue;
+                }
+            };
+            if let Some(reason) = envelope_drift(&ce.entry.manifest, &actual) {
+                drift.push(format!("{site}: {reason}"));
             }
-        };
-        let committed = match git::show_in(dir.path(), rev, &manifest_path)? {
-            Some(committed) => committed,
-            None => {
-                drift.push(format!(
-                    "{}: {manifest_path} absent at pinned commit",
-                    ce.rel
-                ));
-                continue;
-            }
-        };
-        let actual: Manifest = match serde_yaml::from_str(&committed) {
-            Ok(actual) => actual,
-            Err(e) => {
-                drift.push(format!(
-                    "{}: committed {MANIFEST_FILENAME} is unparseable: {e}",
-                    ce.rel
-                ));
-                continue;
-            }
-        };
-        if let Some(reason) = envelope_drift(&ce.entry.manifest, &actual) {
-            drift.push(format!("{}: {reason}", ce.rel));
         }
     }
 

--- a/index-ci/src/integrity.rs
+++ b/index-ci/src/integrity.rs
@@ -66,7 +66,7 @@ pub fn run(root: &Path, sample: Option<usize>) -> eyre::Result<i32> {
                 Ok(actual) => actual,
                 Err(e) => {
                     drift.push(format!(
-                        "{site}: committed {MANIFEST_FILENAME} is unparseable: {e}"
+                        "{site}: committed {MANIFEST_FILENAME} is unparsable: {e}"
                     ));
                     continue;
                 }

--- a/index-ci/src/lib.rs
+++ b/index-ci/src/lib.rs
@@ -1,16 +1,21 @@
 //! Enforcement + auto-merge gate for the dora-hub `node-index/` catalog (§7).
 //!
-//! Four subcommands, mirroring the spec's machine-enforced rules:
-//! - `validate`     — schema (serde), pins, path/name, sibling package, symlinks;
-//! - `append-only`  — published versions are immutable (§7.5);
-//! - `namespace`    — reserved + confusable screening of new claims (§7.4);
-//! - `decide`       — the auto-merge MERGE/HOLD verdict for the bot (§7.5).
+//! Subcommands mirroring the spec's machine-enforced rules:
+//! - `validate`        — schema (serde), pins, path/name, sibling package, symlinks;
+//! - `append-only`     — published versions are immutable (§7.5);
+//! - `namespace`       — reserved + confusable screening of new claims (§7.4);
+//! - `decide`          — the auto-merge MERGE/HOLD verdict for the bot (§7.5);
+//! - `reachability`    — pinned sources still fetch (P3.4, periodic);
+//! - `integrity-audit` — entries still match their pinned source (P3.4, periodic).
 
 pub mod append_only;
+pub mod catalog;
 pub mod decide;
 pub mod git;
+pub mod integrity;
 pub mod model;
 pub mod namespace;
+pub mod reachability;
 pub mod validate;
 
 /// A valid namespace/name path segment of a package key (mirrors

--- a/index-ci/src/lib.rs
+++ b/index-ci/src/lib.rs
@@ -18,6 +18,16 @@ pub mod namespace;
 pub mod reachability;
 pub mod validate;
 
+/// Label an audit finding by its source-chain position: the entry path for the
+/// primary source, or `<rel> (fallback N)` for a `fallback-git` level.
+pub fn audit_site(rel: &str, depth: usize) -> String {
+    if depth == 0 {
+        rel.to_owned()
+    } else {
+        format!("{rel} (fallback {depth})")
+    }
+}
+
 /// A valid namespace/name path segment of a package key (mirrors
 /// `dora-hub-client`'s `index::is_valid_key_part`): a bounded `[A-Za-z0-9._-]`
 /// token, non-empty, not starting with `.` (so `..`/dotfiles can't traverse).

--- a/index-ci/src/main.rs
+++ b/index-ci/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
-use dora_index_ci::{append_only, decide, namespace, validate};
+use dora_index_ci::{append_only, decide, integrity, namespace, reachability, validate};
 
 #[derive(Parser)]
 #[command(about = "Enforcement + auto-merge gate for the dora-hub node-index/ catalog")]
@@ -38,6 +38,21 @@ enum Command {
         #[arg(long)]
         base: String,
     },
+    /// Re-check that every pinned source still fetches (P3.4, periodic).
+    Reachability {
+        /// The catalog root (the `node-index/` directory).
+        #[arg(long, default_value = "node-index")]
+        root: PathBuf,
+    },
+    /// Re-check that entries still match their pinned source (P3.4, periodic).
+    IntegrityAudit {
+        /// The catalog root (the `node-index/` directory).
+        #[arg(long, default_value = "node-index")]
+        root: PathBuf,
+        /// Audit only the first N entries (sorted); omit to audit all.
+        #[arg(long)]
+        sample: Option<usize>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -47,6 +62,8 @@ fn main() -> ExitCode {
         Command::AppendOnly { base } => append_only::run(&base),
         Command::Namespace { base } => namespace::run(&base),
         Command::Decide { author, base } => decide::run(&author, &base),
+        Command::Reachability { root } => reachability::run(&root),
+        Command::IntegrityAudit { root, sample } => integrity::run(&root, sample),
     };
     match result {
         Ok(code) => ExitCode::from(code as u8),

--- a/index-ci/src/model.rs
+++ b/index-ci/src/model.rs
@@ -86,6 +86,38 @@ pub struct PackageMeta {
     pub owners: Vec<String>,
 }
 
+/// One git-pinned level of a source's primary → `fallback-git` chain.
+pub struct GitPin<'a> {
+    pub git: &'a str,
+    pub rev: &'a str,
+    pub subdir: Option<&'a str>,
+    /// 0 = the primary source; 1+ = position in the `fallback-git` chain.
+    pub depth: usize,
+}
+
+/// Every git-pinned level reachable from `source`, walking the `fallback-git`
+/// chain. Binary-only levels contribute nothing. The audits re-check each of
+/// these — a primary *and* a fallback can independently rot, and validation
+/// requires a `fallback-git` to be a full pinned source too (§8.1).
+pub fn git_pins(source: &SourceSpec) -> Vec<GitPin<'_>> {
+    let mut out = Vec::new();
+    let mut cur = Some(source);
+    let mut depth = 0;
+    while let Some(s) = cur {
+        if let (Some(git), Some(rev)) = (&s.git, &s.rev) {
+            out.push(GitPin {
+                git,
+                rev,
+                subdir: s.subdir.as_deref(),
+                depth,
+            });
+        }
+        cur = s.fallback_git.as_deref();
+        depth += 1;
+    }
+    out
+}
+
 impl IndexEntry {
     pub fn parse(yaml: &str) -> eyre::Result<Self> {
         Ok(serde_yaml::from_str(yaml)?)
@@ -95,5 +127,65 @@ impl IndexEntry {
 impl PackageMeta {
     pub fn parse(yaml: &str) -> eyre::Result<Self> {
         Ok(serde_yaml::from_str(yaml)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(yaml: &str) -> SourceSpec {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn git_pins_includes_a_fallback_under_a_binary_primary() {
+        // a binary-primary entry can still pin a git fallback — the audits must
+        // re-check it (the gap this fixes), so it shows up as a depth-1 pin
+        let s = source(
+            "
+binary:
+  - platform: x86_64-unknown-linux-gnu
+    url: https://example.com/x.tgz
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+fallback-git:
+  git: https://example.com/r.git
+  rev: 1111111111111111111111111111111111111111
+  subdir: nodes/n
+",
+        );
+        let pins = git_pins(&s);
+        assert_eq!(pins.len(), 1);
+        assert_eq!(pins[0].depth, 1);
+        assert_eq!(pins[0].subdir, Some("nodes/n"));
+    }
+
+    #[test]
+    fn git_pins_includes_primary_and_fallback() {
+        let s = source(
+            "
+git: https://example.com/a.git
+rev: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+fallback-git:
+  git: https://example.com/b.git
+  rev: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+",
+        );
+        let pins = git_pins(&s);
+        assert_eq!(pins.len(), 2);
+        assert_eq!((pins[0].depth, pins[1].depth), (0, 1));
+    }
+
+    #[test]
+    fn git_pins_empty_for_a_pure_binary_entry() {
+        let s = source(
+            "
+binary:
+  - platform: x86_64-unknown-linux-gnu
+    url: https://example.com/x.tgz
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+        );
+        assert!(git_pins(&s).is_empty());
     }
 }

--- a/index-ci/src/reachability.rs
+++ b/index-ci/src/reachability.rs
@@ -9,6 +9,7 @@
 
 use std::path::Path;
 
+use crate::model::git_pins;
 use crate::{catalog, git};
 
 pub fn run(root: &Path) -> eyre::Result<i32> {
@@ -21,16 +22,18 @@ pub fn run(root: &Path) -> eyre::Result<i32> {
         if ce.entry.yanked {
             continue;
         }
-        let (git_url, rev) = match (&ce.entry.source.git, &ce.entry.source.rev) {
-            (Some(g), Some(r)) => (g, r),
-            _ => {
-                binary_only += 1;
-                continue;
+        // re-check every git-pinned level — the primary source *and* each
+        // `fallback-git` (a binary-primary entry can still pin a git fallback)
+        let pins = git_pins(&ce.entry.source);
+        if pins.is_empty() {
+            binary_only += 1;
+            continue;
+        }
+        for pin in pins {
+            checked += 1;
+            if let Err(e) = git::shallow_fetch(pin.git, pin.rev) {
+                failed.push(format!("{}: {e:#}", super::audit_site(&ce.rel, pin.depth)));
             }
-        };
-        checked += 1;
-        if let Err(e) = git::shallow_fetch(git_url, rev) {
-            failed.push(format!("{}: {e:#}", ce.rel));
         }
     }
 

--- a/index-ci/src/reachability.rs
+++ b/index-ci/src/reachability.rs
@@ -1,0 +1,57 @@
+//! Pin reachability re-check (spec P3.4, §7.5/§11): for every git-pinned catalog
+//! entry, confirm the remote and the exact pinned `rev` still fetch. Catches
+//! deleted repos, force-pushed-away commits, and otherwise-rotted sources.
+//!
+//! This *surfaces a report* rather than mutating entries — it exits non-zero
+//! when a source has rotted (so a scheduled run goes red / can file an issue)
+//! but never edits the index. Yanked versions are skipped (a yanked version's
+//! source is allowed to disappear); binary-only entries have no git rev to check.
+
+use std::path::Path;
+
+use crate::{catalog, git};
+
+pub fn run(root: &Path) -> eyre::Result<i32> {
+    let entries = catalog::version_entries(root)?;
+    let mut checked = 0usize;
+    let mut binary_only = 0usize;
+    let mut failed: Vec<String> = Vec::new();
+
+    for ce in &entries {
+        if ce.entry.yanked {
+            continue;
+        }
+        let (git_url, rev) = match (&ce.entry.source.git, &ce.entry.source.rev) {
+            (Some(g), Some(r)) => (g, r),
+            _ => {
+                binary_only += 1;
+                continue;
+            }
+        };
+        checked += 1;
+        if let Err(e) = git::shallow_fetch(git_url, rev) {
+            failed.push(format!("{}: {e:#}", ce.rel));
+        }
+    }
+
+    for f in &failed {
+        println!("::error::{f}");
+    }
+
+    if checked == 0 {
+        println!(
+            "reachability: OK (no git-pinned entries to check; {binary_only} binary-only skipped)"
+        );
+        return Ok(0);
+    }
+    if failed.is_empty() {
+        println!("reachability: OK ({checked} source(s) reachable)");
+        Ok(0)
+    } else {
+        println!(
+            "reachability: {} of {checked} source(s) UNREACHABLE",
+            failed.len()
+        );
+        Ok(1)
+    }
+}

--- a/index-ci/tests/audit-e2e.rs
+++ b/index-ci/tests/audit-e2e.rs
@@ -69,6 +69,19 @@ fn entry_yaml(name: &str, git_url: &str, rev: &str, yanked: bool, binary: bool) 
     )
 }
 
+/// A binary-primary entry whose `fallback-git` pins `git_url`@`rev` (manifest at
+/// the repo root); the stored manifest claims `name`. Exercises the path where
+/// the top-level source has no git rev but a fallback does.
+fn binary_with_fallback(name: &str, git_url: &str, rev: &str) -> String {
+    format!(
+        "manifest:\n  apiVersion: 1\n  name: {name}\n  namespace: acme\n  \
+         runtime: rust\n  entrypoint: e\nsource:\n  binary:\n    - platform: \
+         x86_64-unknown-linux-gnu\n      url: https://example.com/n.tar.gz\n      \
+         sha256: 0000000000000000000000000000000000000000000000000000000000000000\n  \
+         fallback-git:\n    git: {git_url}\n    rev: {rev}\n"
+    )
+}
+
 #[test]
 fn reachability_passes_for_a_live_pin_and_fails_for_a_rotted_one() {
     let (repo, sha) = source_repo(&manifest("n"));
@@ -152,4 +165,58 @@ fn audits_no_op_on_an_empty_catalog() {
     let empty = tempfile::tempdir().unwrap();
     assert_eq!(reachability::run(empty.path()).unwrap(), 0);
     assert_eq!(integrity::run(empty.path(), None).unwrap(), 0);
+}
+
+#[test]
+fn reachability_rechecks_a_git_fallback_under_a_binary_primary() {
+    let (repo, sha) = source_repo(&manifest("n"));
+    let url = repo.path().to_str().unwrap();
+
+    // binary primary + LIVE git fallback → reachable
+    let live = tempfile::tempdir().unwrap();
+    write_entry(
+        live.path(),
+        "n",
+        "1.0.0",
+        &binary_with_fallback("n", url, &sha),
+    );
+    assert_eq!(reachability::run(live.path()).unwrap(), 0);
+
+    // binary primary + ROTTED git fallback → the gap this fixes: must fail, not
+    // be waved through as "binary-only"
+    let rotted = tempfile::tempdir().unwrap();
+    let gone = "0".repeat(40);
+    write_entry(
+        rotted.path(),
+        "n",
+        "1.0.0",
+        &binary_with_fallback("n", url, &gone),
+    );
+    assert_eq!(reachability::run(rotted.path()).unwrap(), 1);
+}
+
+#[test]
+fn integrity_audits_a_git_fallback_manifest() {
+    let (repo, sha) = source_repo(&manifest("n"));
+    let url = repo.path().to_str().unwrap();
+
+    // fallback's committed manifest matches the stored snapshot
+    let ok = tempfile::tempdir().unwrap();
+    write_entry(
+        ok.path(),
+        "n",
+        "1.0.0",
+        &binary_with_fallback("n", url, &sha),
+    );
+    assert_eq!(integrity::run(ok.path(), None).unwrap(), 0);
+
+    // entry claims a name the fallback's committed manifest doesn't → drift
+    let tampered = tempfile::tempdir().unwrap();
+    write_entry(
+        tampered.path(),
+        "n",
+        "1.0.0",
+        &binary_with_fallback("evil", url, &sha),
+    );
+    assert_eq!(integrity::run(tampered.path(), None).unwrap(), 1);
 }

--- a/index-ci/tests/audit-e2e.rs
+++ b/index-ci/tests/audit-e2e.rs
@@ -1,0 +1,155 @@
+//! End-to-end tests for the periodic audit subcommands (`reachability`,
+//! `integrity-audit`) against a *real* local git source repo and a synthetic
+//! catalog — no network. The pinned `git` is the local repo's path and the
+//! `rev` is a real commit SHA, so `git fetch`/`git show` run for real.
+
+use std::path::Path;
+use std::process::Command;
+
+use dora_index_ci::{integrity, reachability};
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .args(["-C", dir.to_str().unwrap()])
+        .args(args)
+        .status()
+        .unwrap()
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+/// A local git repo with `dora-node.yml` (and the given body) committed; returns
+/// the repo dir and the commit SHA.
+fn source_repo(manifest_body: &str) -> (TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    git(dir.path(), &["init", "-q"]);
+    git(dir.path(), &["config", "user.email", "t@example.com"]);
+    git(dir.path(), &["config", "user.name", "tester"]);
+    std::fs::write(dir.path().join("dora-node.yml"), manifest_body).unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "init"]);
+    let sha = String::from_utf8(
+        Command::new("git")
+            .args(["-C", dir.path().to_str().unwrap(), "rev-parse", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_owned();
+    (dir, sha)
+}
+
+fn manifest(name: &str) -> String {
+    format!("apiVersion: 1\nname: {name}\nnamespace: acme\nruntime: rust\nentrypoint: e\n")
+}
+
+/// Write `node-index/acme/<name>/<ver>.yml` + sibling `package.yml`.
+fn write_entry(catalog: &Path, name: &str, ver: &str, entry_yaml: &str) {
+    let dir = catalog.join("acme").join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(format!("{ver}.yml")), entry_yaml).unwrap();
+    std::fs::write(dir.join("package.yml"), "owners: [acme]\n").unwrap();
+}
+
+fn entry_yaml(name: &str, git_url: &str, rev: &str, yanked: bool, binary: bool) -> String {
+    let source = if binary {
+        "source:\n  binary:\n    - platform: x86_64-unknown-linux-gnu\n      \
+         url: https://example.com/n.tar.gz\n      \
+         sha256: 0000000000000000000000000000000000000000000000000000000000000000\n"
+            .to_owned()
+    } else {
+        format!("source:\n  git: {git_url}\n  rev: {rev}\n")
+    };
+    format!(
+        "manifest:\n  apiVersion: 1\n  name: {name}\n  namespace: acme\n  \
+         runtime: rust\n  entrypoint: e\n{source}yanked: {yanked}\n"
+    )
+}
+
+#[test]
+fn reachability_passes_for_a_live_pin_and_fails_for_a_rotted_one() {
+    let (repo, sha) = source_repo(&manifest("n"));
+    let url = repo.path().to_str().unwrap();
+
+    let live = tempfile::tempdir().unwrap();
+    write_entry(
+        live.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("n", url, &sha, false, false),
+    );
+    assert_eq!(reachability::run(live.path()).unwrap(), 0);
+
+    // a force-pushed-away / never-existed commit → unreachable → exit 1
+    let rotted = tempfile::tempdir().unwrap();
+    let gone = "0".repeat(40);
+    write_entry(
+        rotted.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("n", url, &gone, false, false),
+    );
+    assert_eq!(reachability::run(rotted.path()).unwrap(), 1);
+}
+
+#[test]
+fn reachability_skips_yanked_and_binary_only_entries() {
+    let url = "/this/path/does/not/exist.git";
+    let gone = "0".repeat(40);
+
+    // a yanked entry whose source is gone must not fail the run
+    let yanked = tempfile::tempdir().unwrap();
+    write_entry(
+        yanked.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("n", url, &gone, true, false),
+    );
+    assert_eq!(reachability::run(yanked.path()).unwrap(), 0);
+
+    // a binary-only entry has no git rev to re-check
+    let binary = tempfile::tempdir().unwrap();
+    write_entry(
+        binary.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("n", "", "", false, true),
+    );
+    assert_eq!(reachability::run(binary.path()).unwrap(), 0);
+}
+
+#[test]
+fn integrity_audit_passes_on_match_and_fails_on_rewritten_entry() {
+    let (repo, sha) = source_repo(&manifest("n"));
+    let url = repo.path().to_str().unwrap();
+
+    // entry manifest matches what's committed at the pinned commit
+    let ok = tempfile::tempdir().unwrap();
+    write_entry(
+        ok.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("n", url, &sha, false, false),
+    );
+    assert_eq!(integrity::run(ok.path(), None).unwrap(), 0);
+
+    // entry claims `name: evil` but the pinned commit's manifest says `name: n`
+    let tampered = tempfile::tempdir().unwrap();
+    write_entry(
+        tampered.path(),
+        "n",
+        "1.0.0",
+        &entry_yaml("evil", url, &sha, false, false),
+    );
+    assert_eq!(integrity::run(tampered.path(), None).unwrap(), 1);
+}
+
+#[test]
+fn audits_no_op_on_an_empty_catalog() {
+    let empty = tempfile::tempdir().unwrap();
+    assert_eq!(reachability::run(empty.path()).unwrap(), 0);
+    assert_eq!(integrity::run(empty.path(), None).unwrap(), 0);
+}

--- a/node-hub/dora-mcp-host/src/main.rs
+++ b/node-hub/dora-mcp-host/src/main.rs
@@ -93,12 +93,8 @@ async fn main() -> eyre::Result<()> {
                         .iter()
                         .map(|msg| msg.to_texts().join("\n"))
                         .collect::<Vec<_>>();
-                    node.send_output(
-                        DataId::from(output),
-                        metadata,
-                        StringArray::from(texts),
-                    )
-                    .context("failed to send dora output")?;
+                    node.send_output(DataId::from(output), metadata, StringArray::from(texts))
+                        .context("failed to send dora output")?;
 
                     reply_channels.insert(call_id, (reply, 0_u32, Some(request.model)));
                 }


### PR DESCRIPTION
Implements the code-buildable part of **Phase 3.4** (#64): two periodic catalog-hardening subcommands in `dora-index-ci`, plus a weekly workflow.

## What

| Subcommand | Catches | Skips |
|---|---|---|
| `reachability` | deleted repos, force-pushed-away commits, rotted sources (re-fetches each entry's exact `rev`) | yanked + binary-only entries |
| `integrity-audit` | a rewritten entry whose manifest disagrees with the manifest committed at its pinned `rev` (compares envelope fields) | binary-only entries |

Both **surface a report** (exit non-zero on a problem) rather than mutating entries, run **only against `node-index/**`** (never the human-reviewed `node-hub/` path, per spec §7.5), and **no-op cleanly (exit 0) on an empty catalog**.

## Safe to land before the catalog exists

`origin/main` has zero index entries today (the catalog is bootstrapped by P2.3 / #65, entries seeded by #85). Both subcommands return `OK` exit 0 when there's nothing to check, so the scheduled workflow is a clean no-op until the catalog is populated, then activates automatically.

```
$ dora-index-ci reachability
reachability: OK (no git-pinned entries to check; 0 binary-only skipped)
$ dora-index-ci integrity-audit
integrity-audit: OK (no git-pinned entries to audit)
```

## Scope note — confusable tuning deferred

#64's third task (confusable-threshold tuning) is **not** in this PR: it can only be calibrated against the real namespace corpus, which lands with the index entries (#85). The detection *mechanism* already exists (`namespace.rs`); this PR adds the two checks that only needed the tooling, not the corpus.

## Implementation

- `git::shallow_fetch` (injection-guarded: rejects option-shaped URLs + non-hex revs before shelling out) + `git::show_in`
- `catalog::version_entries` (shared catalog walk; skips `package.yml`/symlinks; warns + skips unparseable entries — `validate` is the PR gate)
- `.github/workflows/node-index-audit.yml` — **schedule (weekly) + manual only**, not on PRs (gating PRs on network fetches would be slow/flaky once the catalog grows)

## Test plan

- [x] `cargo test -p dora-index-ci` — 5 lib unit + 4 e2e + 10 existing integration, all green
- [x] `cargo clippy -p dora-index-ci --all-targets` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `audit-e2e.rs` drives both subcommands against a **real local git repo** (no network): live-pin pass, rotted-pin fail, rewritten-entry drift, yanked/binary skip, empty-catalog no-op
- [x] tooling regression-tested on PRs via `node-index-ci.yml`'s existing `cargo test` step

Closes #64 (modulo the corpus-dependent confusable tuning, tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
