### PR TITLE
feat(node-index): bootstrap-activation — seed dora-rs/dora-echo + maintainer checklist (#65)

### DIFF
--- a/node-index/BOOTSTRAP.md
+++ b/node-index/BOOTSTRAP.md
@@ -1,0 +1,77 @@
+# node-index bootstrap — maintainer activation checklist
+
+The catalog machinery (Hub spec §7 / roadmap P2.3) is **built and tested** in
+this repo:
+
+| Piece | Where |
+|-------|-------|
+| Catalog layout (`node-index/<ns>/<name>/{package.yml,<ver>.yml}`) | this directory |
+| Schema + pin + path validation, append-only, namespace governance | `index-ci` crate (`validate` / `append-only` / `namespace` / `decide`) |
+| Path-scoped PR CI | `.github/workflows/node-index-ci.yml` |
+| Auto-merge bot | `.github/workflows/index-auto-merge.yml` |
+| Weekly reachability + integrity audits (P3.4) | `.github/workflows/node-index-audit.yml` |
+
+What was missing was a **non-empty catalog** and the **repo settings** that let
+the bot actually merge. The PR that adds this file also adds the first real
+entry (`dora-rs/dora-echo`), which validates, fetches, and audits clean — proof
+the pipeline runs end-to-end. The remaining steps are maintainer-only repo
+settings.
+
+## 1. Enable the auto-merge bot (repo settings)
+
+The bot (`index-auto-merge.yml`) runs the trusted gate and, on a routine
+owner publish, calls `gh pr merge --squash --auto`. That requires:
+
+- [ ] **Allow auto-merge** — Settings → General → Pull Requests →
+  check *“Allow auto-merge.”* Without it the bot logs
+  *“could not enable auto-merge”* and does nothing.
+- [ ] **Branch protection on `main`** — Settings → Branches → add a rule for
+  `main` that **requires the `index-checks` status check** (the job in
+  `node-index CI`) to pass before merging. This is what makes `--auto` wait
+  for green instead of merging blind. Do **not** require the per-node
+  `node-hub` matrix or the scheduled audit here — only `index-checks`.
+- [ ] **Workflow write permission** — the workflow already declares
+  `permissions: { contents: write, pull-requests: write }` and uses the
+  built-in `GITHUB_TOKEN` via `pull_request_target`, so **no PAT is needed**.
+  Just confirm Settings → Actions → General → Workflow permissions is not set
+  to *read-only* (the explicit block overrides it, but confirm org policy
+  doesn’t block it).
+
+The bot uses `pull_request_target` and builds the gate from the **base** ref,
+checking out the PR head as **data only** (its YAML is parsed, never built or
+executed) — so a forked publish PR cannot run code in the privileged context.
+
+## 2. Confirm namespace OWNERS
+
+- [ ] Review `node-index/dora-rs/*/package.yml` — the seed proposes
+  `haixuanTao` and `phil-opp` as `dora-rs` owners. Adjust to the real owner
+  set. `decide` reads OWNERS from the **base tip**, so only owners listed on
+  `main` can have routine publishes auto-merged.
+- [ ] `dora-rs` is a **reserved** namespace, so its first claim needs an index
+  admin (a human). The seed PR *is* that first claim — review and merge it by
+  hand. The bot will `HOLD` it automatically (reserved + new namespace).
+
+## 3. Activation sequence
+
+1. **Merge the seed PR by hand** (the bot holds it — reserved/new namespace).
+   → catalog has its first resolvable entry.
+2. **Flip the two settings in §1.**
+3. **Merge #85** (the remaining migrated entries) — the first real exercise of
+   the now-live bot. New namespaces / OWNERS lines in it still route to a human.
+4. The weekly `node-index-audit.yml` then re-checks every pinned source.
+
+## How the gate decides (reference)
+
+A `node-index/**` PR auto-merges only when **all three** pass:
+
+- `validate` — schema, full-hash pins, confined `subdir`, well-formed git URL,
+  sibling `package.yml` with ≥1 valid owner, no symlinks.
+- `append-only` — a published `<ver>.yml` is immutable; the only allowed edits
+  are flipping `yanked` (+reason) and *adding* late `source.binary` platforms.
+- `decide` — the PR touches only version files in an **existing** namespace,
+  every change is an add, no new namespace is claimed, and every entry is
+  authored by an **owner** of its namespace.
+
+Anything else (new namespace, OWNERS change, yank by a non-owner, edits to the
+index CI/bot itself) is **HOLD** — left for a human. Correctness is still gated
+by `node-index CI` regardless.

--- a/node-index/dora-rs/dora-echo/0.5.0.yml
+++ b/node-index/dora-rs/dora-echo/0.5.0.yml
@@ -1,0 +1,36 @@
+manifest:
+  apiVersion: 1
+  name: dora-echo
+  namespace: dora-rs
+  description: Echoes every input it receives straight back out under the same id.
+  categories: [debug, transform]
+  keywords: [echo, passthrough, loopback, debug, test]
+  runtime: python
+  entrypoint: dora-echo
+  build: pip install .
+  dora: ">=0.3.9"
+  platforms: []
+  # dora-echo re-sends any input back under the same id. The code handles any id,
+  # but a Hub contract must declare every wired input/output (undeclared ones fail
+  # the build), so it declares one generic `data` in/out. Wire to `data` for Hub
+  # usage, or run via `path:` for arbitrary ids.
+  inputs:
+    data:
+      required: false
+      description: The value to echo back. Returned unchanged on the `data` output.
+  outputs:
+    data:
+      description: The `data` input, re-sent unchanged (same value and metadata).
+  example: |
+    - id: echo
+      hub: dora-echo@^0.5
+      inputs:
+        data: some-node/output
+      outputs:
+        - data
+source:
+  git: https://github.com/dora-rs/dora-hub
+  rev: eb118a6a637472a0703bda1317478be9a09fef10
+  subdir: node-hub/dora-echo
+published: 2026-06-17T00:00:00Z
+yanked: false

--- a/node-index/dora-rs/dora-echo/package.yml
+++ b/node-index/dora-rs/dora-echo/package.yml
@@ -1,0 +1,5 @@
+description: Official dora-rs nodes.
+repo: https://github.com/dora-rs/dora-hub
+owners:
+  - haixuanTao
+  - phil-opp


### PR DESCRIPTION
Unblocks the code/doc half of **P2.3 / #65** (the catalog bootstrap keystone).

## Why

The catalog machinery is already built and tested — `index-ci`
(`validate`/`append-only`/`namespace`/`decide`), `node-index-ci.yml`, the
`index-auto-merge.yml` bot, and the P3.4 audits (#86). What was missing was a
**non-empty catalog** and the **repo settings** that let the bot actually merge.
#65's checklist long predates all of that, so the issue reads as "needs
unspecified maintainer magic." This PR closes the buildable gap and turns the
rest into a documented switch-flip.

## What

- **`node-index/dora-rs/dora-echo/0.5.0.yml` + `package.yml`** — the first real
  entry, pinned to this repo's own `node-hub/dora-echo` at `eb118a6` (the
  node's actual source). Not a throwaway fixture: it validates, its source
  fetches, and `integrity-audit` confirms the manifest matches the pinned
  commit.
- **`node-index/BOOTSTRAP.md`** — the maintainer activation checklist: the two
  repo settings the bot needs, OWNERS confirmation, and the activation sequence.

## Proof-of-life (run locally against the real pin)

```
$ dora-index-ci validate
::warning::dora-rs/dora-echo/package.yml: namespace `dora-rs` is reserved — needs an index admin (§7.4)
validate: OK (2 file(s) checked)
$ dora-index-ci reachability      # fetches dora-hub@eb118a6 over the network
reachability: OK (1 source(s) reachable)
$ dora-index-ci integrity-audit
integrity-audit: OK (1 entr(ies) match their pinned source)
```

## Expected bot verdict: HOLD (by design)

`dora-rs` is reserved and newly claimed, so the gate correctly holds this PR for
human review — it's the canonical first-claim review:

```
validate: OK   append-only: OK (3 adds)   namespace: 1 new claim flagged
decide: HOLD — new namespace `dora-rs`; touches BOOTSTRAP.md + package.yml
```

So this PR also serves as a live test of the governance carve-out: the bot will
**not** auto-merge it; a maintainer merges it by hand.

## Maintainer next steps (see `BOOTSTRAP.md`)

1. Merge this PR by hand (the bot holds it).
2. Enable **Allow auto-merge** + add branch protection on `main` requiring the
   `index-checks` status check.
3. Confirm the `dora-rs` OWNERS (this PR proposes `haixuanTao`, `phil-opp`).
4. Merge #85 (remaining migrated entries) — first real exercise of the live bot.

## Coordination notes

- **#85 overlap:** that draft seeds all 62 nodes incl. `dora-echo`. Once this
  lands, drop `dora-echo` from #85 (append-only rejects a re-add of an existing
  published file) — or rebase #85 to exclude it.
- Touches only `node-index/**`; does not affect the human-reviewed `node-hub/`
  source path.

## Test plan

- [x] `dora-index-ci validate / reachability / integrity-audit` — all green on the seed
- [x] `append-only` / `namespace` / `decide` produce the expected ADD / flag / HOLD verdicts
- [x] `cargo test -p dora-index-ci`, `cargo fmt -- --check` — clean

Refs #65, #63, #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
