### PR TITLE
feat(index-ci): namespace-identity binding gate (§7.4, #65)

### DIFF
--- a/.github/workflows/node-index-ci.yml
+++ b/.github/workflows/node-index-ci.yml
@@ -35,3 +35,11 @@ jobs:
         run: ./target/release/dora-index-ci append-only --base "origin/${{ github.base_ref }}"
       - name: Namespace governance (§7.4 reserved + confusable)
         run: ./target/release/dora-index-ci namespace --base "origin/${{ github.base_ref }}"
+      - name: Namespace-identity binding (§7.4 — author owns the claimed namespace)
+        env:
+          # public-API reads; lifts the unauthenticated rate limit
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ./target/release/dora-index-ci identity \
+            --author "${{ github.event.pull_request.user.login }}" \
+            --base "origin/${{ github.base_ref }}"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 # Rust nodes that need system libs / are heavy are excluded, matching ci.yml.
 RUST_EXCLUDES := --exclude dora-dav1d --exclude dora-rav1e --exclude dora-qwen-omni
 
+# GitHub login for the §7.4 identity gate in `index-ci`. Only consulted when the
+# tree adds a NEW namespace (otherwise the gate is a no-op), so the default is
+# best-effort: your gh-authenticated login. Override for a real new-namespace
+# claim: `make index-ci AUTHOR=<your-login>`.
+AUTHOR ?= $(shell gh api user --jq .login 2>/dev/null || echo unknown)
+
 .PHONY: help
 help:
 	@echo "dora-hub dev targets:"
@@ -9,7 +15,7 @@ help:
 	@echo "  make lint                    ruff (repo Python) + rustfmt --check + clippy"
 	@echo "  make fmt                     cargo fmt + ruff format (repo Python)"
 	@echo "  make test-rust               cargo test for the Rust workspace"
-	@echo "  make index-ci                node-index schema + append-only checks"
+	@echo "  make index-ci                node-index gates: schema + append-only + namespace + identity"
 	@echo "  make typos                   spell-check (crate-ci/typos)"
 	@echo "  make qa                      pre-commit static gates: lint + index-ci + typos"
 
@@ -39,7 +45,8 @@ index-ci:
 	  cargo test -p dora-index-ci && \
 	  cargo run -q -p dora-index-ci -- validate && \
 	  cargo run -q -p dora-index-ci -- append-only --base origin/main && \
-	  cargo run -q -p dora-index-ci -- namespace --base origin/main; \
+	  cargo run -q -p dora-index-ci -- namespace --base origin/main && \
+	  cargo run -q -p dora-index-ci -- identity --author "$(AUTHOR)" --base origin/main; \
 	else echo "index-ci: no node-index/ catalog in this tree — skipping"; fi
 
 .PHONY: typos

--- a/index-ci/src/identity.rs
+++ b/index-ci/src/identity.rs
@@ -1,0 +1,273 @@
+//! Namespace-identity binding (spec §7.4): a *newly-claimed* namespace must
+//! match the claiming PR author's GitHub identity — their own login, or an
+//! organization they belong to.
+//!
+//! GitHub only exposes *public* org membership, and most memberships are
+//! private, so "not a public member" is ambiguous (impersonation **or** a
+//! legitimate private member). We therefore only **reject** the one case we can
+//! confirm is wrong — a namespace that is another real user's login — and route
+//! every ambiguous case (org with non-public membership, unknown account, API
+//! unreachable) to **human review** rather than failing. New namespaces already
+//! get a mandatory human (`decide` HOLDs them); this adds an auto-verify signal
+//! and a hard stop for personal-namespace impersonation (#2201: "CI rejects a
+//! namespace-identity mismatch").
+//!
+//! Lookups shell out to `curl` against the public GitHub API (mirroring how
+//! `git.rs` shells out to `git`), keeping the crate's offline-by-default
+//! dependency set. `GITHUB_TOKEN`/`GH_TOKEN`, if set, only lifts the rate limit.
+
+use std::process::Command;
+
+use eyre::Context;
+
+use crate::git;
+
+/// Whether `author` is a *public* member of the org (from `public_members`).
+#[derive(Debug, PartialEq, Eq)]
+enum Membership {
+    Member,
+    NotMember,
+    Unverifiable,
+}
+
+/// What the claimed namespace resolves to on GitHub.
+#[derive(Debug, PartialEq, Eq)]
+enum Account {
+    /// An organization, plus whether the author is a public member.
+    Org(Membership),
+    /// A real user account (and — checked by the caller — not the author).
+    User,
+    /// No such user or org.
+    None,
+    /// The API could not be reached / gave an unexpected status.
+    Unverifiable,
+}
+
+enum Verdict {
+    Verified(String),
+    Review(String),
+    Reject(String),
+}
+
+/// GitHub logins are case-insensitive, so a personal namespace matches its
+/// owner's login regardless of case.
+fn personal_match(ns: &str, author: &str) -> bool {
+    ns.eq_ignore_ascii_case(author)
+}
+
+/// Map a `public_members` HTTP status: 204 = public member, 404 = not public
+/// (private membership or non-member), anything else = can't verify.
+fn membership_from_status(status: Option<u16>) -> Membership {
+    match status {
+        Some(204) => Membership::Member,
+        Some(404) => Membership::NotMember,
+        _ => Membership::Unverifiable,
+    }
+}
+
+/// The verdict for one non-login-matching namespace, given what it resolves to.
+/// Pure — the IO lives in `classify` / `http_status`.
+fn verdict(ns: &str, author: &str, account: Account) -> Verdict {
+    match account {
+        Account::Org(Membership::Member) => {
+            Verdict::Verified(format!("`{author}` is a public member of org `{ns}`"))
+        }
+        Account::Org(Membership::NotMember) => Verdict::Review(format!(
+            "`{author}` is not a *public* member of org `{ns}` (membership may be \
+             private) — confirm the author belongs to it"
+        )),
+        Account::Org(Membership::Unverifiable) => Verdict::Review(format!(
+            "could not verify org `{ns}` membership for `{author}` — review by hand"
+        )),
+        // a real user account that is not the author (login match was checked first)
+        Account::User => Verdict::Reject(format!(
+            "namespace `{ns}` is another user's GitHub login, not author `{author}` \
+             — impersonation (§7.4)"
+        )),
+        Account::None => Verdict::Review(format!(
+            "namespace `{ns}` matches no GitHub user or org — confirm author \
+             `{author}` owns it"
+        )),
+        Account::Unverifiable => Verdict::Review(format!(
+            "could not reach GitHub to verify namespace `{ns}` — re-run or review by hand"
+        )),
+    }
+}
+
+/// Resolve what a claimed namespace is on GitHub (org vs user vs nothing) and,
+/// for an org, whether `author` is a public member.
+fn classify(ns: &str, author: &str) -> eyre::Result<Account> {
+    // guarded before building any URL (both are validated key-parts/logins, but
+    // re-check defensively so a bad value can never reach the API path)
+    if !crate::is_valid_key_part(ns) || !crate::is_valid_login(author) {
+        return Ok(Account::None);
+    }
+    match http_status(&format!("/orgs/{ns}"))? {
+        Some(s) if (200..300).contains(&s) => {
+            let m = membership_from_status(http_status(&format!(
+                "/orgs/{ns}/public_members/{author}"
+            ))?);
+            Ok(Account::Org(m))
+        }
+        Some(404) => match http_status(&format!("/users/{ns}"))? {
+            Some(s) if (200..300).contains(&s) => Ok(Account::User),
+            Some(404) => Ok(Account::None),
+            _ => Ok(Account::Unverifiable),
+        },
+        _ => Ok(Account::Unverifiable),
+    }
+}
+
+/// `GET https://api.github.com{path}` returning just the HTTP status, via `curl`.
+fn http_status(path: &str) -> eyre::Result<Option<u16>> {
+    let url = format!("https://api.github.com{path}");
+    let mut cmd = Command::new("curl");
+    cmd.args([
+        "-s",
+        "-o",
+        "/dev/null",
+        "-w",
+        "%{http_code}",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "User-Agent: dora-index-ci",
+    ]);
+    if let Some(token) = token() {
+        cmd.args(["-H", &format!("Authorization: Bearer {token}")]);
+    }
+    cmd.arg(&url);
+    let out = cmd
+        .output()
+        .context("failed to run `curl` for the GitHub identity check")?;
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<u16>()
+        .ok())
+}
+
+fn token() -> Option<String> {
+    ["GITHUB_TOKEN", "GH_TOKEN"]
+        .iter()
+        .find_map(|k| std::env::var(k).ok())
+        .filter(|t| !t.is_empty())
+}
+
+/// Verify the identity binding of every namespace newly claimed in `base..HEAD`.
+/// Exits non-zero only on a confirmed impersonation; ambiguous claims are
+/// flagged for human review (the new-namespace human gate in `decide` still
+/// applies).
+pub fn run(author: &str, base: &str) -> eyre::Result<i32> {
+    let base_ns = git::namespaces_at(base)?;
+    let head_ns = git::namespaces_at("HEAD")?;
+    let new: Vec<String> = head_ns.difference(&base_ns).cloned().collect();
+
+    if new.is_empty() {
+        println!("identity: OK (no new namespace claims)");
+        return Ok(0);
+    }
+
+    let mut verified = 0usize;
+    let mut review: Vec<String> = Vec::new();
+    let mut reject: Vec<String> = Vec::new();
+    for ns in &new {
+        if personal_match(ns, author) {
+            println!("identity: `{ns}` matches author login `{author}`");
+            verified += 1;
+            continue;
+        }
+        match verdict(ns, author, classify(ns, author)?) {
+            Verdict::Verified(msg) => {
+                println!("identity: {msg}");
+                verified += 1;
+            }
+            Verdict::Review(msg) => review.push(msg),
+            Verdict::Reject(msg) => reject.push(msg),
+        }
+    }
+
+    for r in &review {
+        println!("::warning::{r}");
+    }
+    for r in &reject {
+        println!("::error::{r}");
+    }
+    if !reject.is_empty() {
+        println!(
+            "identity: {} namespace claim(s) REJECTED as impersonation (§7.4)",
+            reject.len()
+        );
+        return Ok(1);
+    }
+    if review.is_empty() {
+        println!("identity: OK ({verified} new namespace claim(s) verified)");
+    } else {
+        println!(
+            "identity: {verified} verified, {} flagged for human review (not a failure)",
+            review.len()
+        );
+    }
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn personal_match_is_case_insensitive() {
+        assert!(personal_match("octocat", "octocat"));
+        assert!(personal_match("OctoCat", "octocat"));
+        assert!(!personal_match("dora-rs", "octocat"));
+    }
+
+    #[test]
+    fn membership_status_mapping() {
+        assert_eq!(membership_from_status(Some(204)), Membership::Member);
+        assert_eq!(membership_from_status(Some(404)), Membership::NotMember);
+        assert_eq!(membership_from_status(Some(403)), Membership::Unverifiable);
+        assert_eq!(membership_from_status(Some(0)), Membership::Unverifiable);
+        assert_eq!(membership_from_status(None), Membership::Unverifiable);
+    }
+
+    #[test]
+    fn only_a_public_org_member_is_verified() {
+        assert!(matches!(
+            verdict("acme", "bob", Account::Org(Membership::Member)),
+            Verdict::Verified(_)
+        ));
+    }
+
+    #[test]
+    fn private_or_unverifiable_org_membership_routes_to_review_not_reject() {
+        // the false-reject trap: a legit private member must NOT be rejected
+        assert!(matches!(
+            verdict("acme", "bob", Account::Org(Membership::NotMember)),
+            Verdict::Review(_)
+        ));
+        assert!(matches!(
+            verdict("acme", "bob", Account::Org(Membership::Unverifiable)),
+            Verdict::Review(_)
+        ));
+    }
+
+    #[test]
+    fn claiming_another_users_login_is_rejected() {
+        assert!(matches!(
+            verdict("torvalds", "bob", Account::User),
+            Verdict::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_or_unverifiable_account_routes_to_review() {
+        assert!(matches!(
+            verdict("acme", "bob", Account::None),
+            Verdict::Review(_)
+        ));
+        assert!(matches!(
+            verdict("acme", "bob", Account::Unverifiable),
+            Verdict::Review(_)
+        ));
+    }
+}

--- a/index-ci/src/lib.rs
+++ b/index-ci/src/lib.rs
@@ -12,11 +12,24 @@ pub mod append_only;
 pub mod catalog;
 pub mod decide;
 pub mod git;
+pub mod identity;
 pub mod integrity;
 pub mod model;
 pub mod namespace;
 pub mod reachability;
 pub mod validate;
+
+/// A valid GitHub login or org: 1–39 chars, alphanumeric with single internal
+/// hyphens (no leading/trailing/double hyphen). Mirrors the package schema's
+/// `owners` pattern; shared by `validate` (owner check) and `identity`.
+pub fn is_valid_login(login: &str) -> bool {
+    !login.is_empty()
+        && login.len() <= 39
+        && login.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && !login.starts_with('-')
+        && !login.ends_with('-')
+        && !login.contains("--")
+}
 
 /// Label an audit finding by its source-chain position: the entry path for the
 /// primary source, or `<rel> (fallback N)` for a `fallback-git` level.

--- a/index-ci/src/main.rs
+++ b/index-ci/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
-use dora_index_ci::{append_only, decide, integrity, namespace, reachability, validate};
+use dora_index_ci::{append_only, decide, identity, integrity, namespace, reachability, validate};
 
 #[derive(Parser)]
 #[command(about = "Enforcement + auto-merge gate for the dora-hub node-index/ catalog")]
@@ -38,6 +38,13 @@ enum Command {
         #[arg(long)]
         base: String,
     },
+    /// Verify a new namespace matches the author's GitHub identity (§7.4).
+    Identity {
+        #[arg(long)]
+        author: String,
+        #[arg(long)]
+        base: String,
+    },
     /// Re-check that every pinned source still fetches (P3.4, periodic).
     Reachability {
         /// The catalog root (the `node-index/` directory).
@@ -62,6 +69,7 @@ fn main() -> ExitCode {
         Command::AppendOnly { base } => append_only::run(&base),
         Command::Namespace { base } => namespace::run(&base),
         Command::Decide { author, base } => decide::run(&author, &base),
+        Command::Identity { author, base } => identity::run(&author, &base),
         Command::Reachability { root } => reachability::run(&root),
         Command::IntegrityAudit { root, sample } => integrity::run(&root, sample),
     };

--- a/index-ci/src/validate.rs
+++ b/index-ci/src/validate.rs
@@ -97,7 +97,7 @@ fn validate_file(
                 // owners are the merge authority for `decide`; each must be a
                 // valid GitHub login/org so a malformed entry can't slip in
                 for owner in &meta.owners {
-                    if !is_valid_owner(owner) {
+                    if !crate::is_valid_login(owner) {
                         errors.push(format!("{rel}: invalid owner `{owner}` (GitHub login/org)"));
                     }
                 }
@@ -187,18 +187,6 @@ pub fn validate_source(source: &SourceSpec) -> eyre::Result<()> {
         validate_source(fb)?;
     }
     Ok(())
-}
-
-/// A valid GitHub login or org: 1–39 chars, alphanumeric with single internal
-/// hyphens (no leading/trailing/double hyphen). Mirrors the old package schema's
-/// `owners` pattern.
-fn is_valid_owner(owner: &str) -> bool {
-    !owner.is_empty()
-        && owner.len() <= 39
-        && owner.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-        && !owner.starts_with('-')
-        && !owner.ends_with('-')
-        && !owner.contains("--")
 }
 
 /// Reject a `subdir` that could escape the checkout: relative, no `..`, single


### PR DESCRIPTION
Implements spec §7.4's **namespace-identity binding** — the last unautomated piece of P2.3 governance (#65 PR2). A newly-claimed namespace must match the claiming PR author's GitHub identity, or the gate flags/rejects it (#2201 acceptance: "CI rejects a namespace-identity mismatch").

## The subtle part: public-membership is incomplete info

GitHub only exposes **public** org membership, and most memberships are private. So `dora-rs/public_members/<author>` returns **404 for a legitimate private member** just as it does for an impersonator — the two are indistinguishable. A naive "not a public member → reject" would **false-reject legitimate publishers**.

So `identity` only **hard-rejects the case it can confirm is wrong**, and routes everything ambiguous to human review (which `decide` already enforces for every new namespace):

| Claimed namespace resolves to… | Verdict | Exit |
|---|---|---|
| author's own login (case-insensitive) | **Verified** | 0 |
| an org the author is a **public** member of | **Verified** | 0 |
| an org, membership not public / unverifiable | **Review** (warning) | 0 |
| **another real user's login** (not the author) | **REJECT — impersonation** | 1 |
| no such user/org, or API unreachable | **Review** (warning) | 0 |

Only personal-namespace impersonation (claiming someone else's GitHub username) fails CI. Org claims with private membership fall to the human review they'd get anyway — no false-rejects.

## Live-verified end to end

```
# octocat is a real GitHub *user*; phil-opp claiming it:
::error::namespace `octocat` is another user's GitHub login, not author `phil-opp` — impersonation (§7.4)
identity: 1 namespace claim(s) REJECTED as impersonation (§7.4)         # exit 1

# github is a real *org*, phil-opp not a public member:
::warning::`phil-opp` is not a *public* member of org `github` (membership may be private) — confirm the author belongs to it   # exit 0 (review, not reject)

# author claims their own login:
identity: `octocat` matches author login `octocat`                      # exit 0
```

## Implementation

- New `identity` subcommand (`--author <login> --base <ref>`), mirroring `decide`. Computes newly-claimed namespaces from `base..HEAD` (same as `namespace`).
- Org/user resolution + public-membership lookup shell out to `curl` against the public GitHub API (mirroring how `git.rs` shells out to `git` — keeps the crate offline-by-default, no HTTP/JSON deps). `GITHUB_TOKEN`/`GH_TOKEN`, if set, only lifts the rate limit.
- Wired into `node-index-ci.yml` as a gate step (`github.event.pull_request.user.login`).
- Promoted `is_valid_owner` → `lib::is_valid_login`, shared by `validate` and `identity` (the same GitHub-login charset rule), removing the duplicate.

The decision logic (`verdict`) is pure and unit-tested across all six cases; the IO (`classify`/`http_status`/git-diff) follows the crate's existing shell-out pattern.

## Test plan

- [x] `cargo test -p dora-index-ci` — 14 lib unit (incl. 6 new identity verdict/mapping tests) + e2e + integration, all green
- [x] `cargo clippy --all-targets` — clean · `cargo fmt -- --check` — clean
- [x] Live-verified against the real GitHub API: impersonation→reject, org→review, login→verify (above)

Closes the §7.4 identity-binding item of #65 / #2201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
