### PR TITLE
docs: document the Dora Hub catalog (README + CONTRIBUTING + node-index)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ dora hub init               # scaffold dora-node.yml (if you haven't already)
 dora validate --node-manifest dora-node.yml
 # commit dora-node.yml + the version bump, push
 dora hub publish --dry-run  # preview the exact index entry
-dora hub publish            # print the entry + open the index PR
+dora hub publish            # print the entry + PR instructions (open the PR manually)
 ```
 
 The catalog is produced by the `dora hub publish` CLI — **don't hand-edit version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,23 @@ on Discord first.
 
 ## Publishing to the Dora Hub
 
-> The `node-index/` catalog and its CI land with the catalog bootstrap (PR #66);
-> this section applies once that merges.
+Publishing makes a node installable with `hub: dora-rs/<name>@<version>`. It adds
+an append-only entry to the `node-index/` catalog that points at a commit of the
+node's source — it does **not** upload code.
 
-The `node-index/` catalog is produced by the `dora hub publish` CLI — **don't
-hand-edit version entries**. Published version files are immutable (append-only,
-enforced by `node-index CI`); a yank is the one allowed mutation. See
-`node-index/README.md` for the format.
+```bash
+cd node-hub/my-node
+dora hub init               # scaffold dora-node.yml (if you haven't already)
+dora validate --node-manifest dora-node.yml
+# commit dora-node.yml + the version bump, push
+dora hub publish --dry-run  # preview the exact index entry
+dora hub publish            # print the entry + open the index PR
+```
+
+The catalog is produced by the `dora hub publish` CLI — **don't hand-edit version
+entries**. Published version files are immutable (append-only, enforced by
+`node-index CI`); a yank (`dora hub yank`) is the one allowed mutation. See
+[`node-index/README.md`](node-index/README.md) for the entry format,
+[`node-index/POLICY.md`](node-index/POLICY.md) for namespaces/ownership, and the
+[Dora Hub guide](https://github.com/dora-rs/dora/blob/main/guide/src/hub/publishing.md)
+for the full walkthrough.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ maintain here:
 cd node-hub/my-node
 dora hub init               # scaffold a dora-node.yml manifest (if needed)
 dora hub publish --dry-run  # preview the exact index entry
-dora hub publish            # open the index PR
+dora hub publish            # print the entry + PR instructions (open the PR manually)
 ```
 
 The catalog is append-only and CI-gated. See [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,51 @@
 
 This hub contains useful pre-built nodes for Dora.
 
+The nodes maintained in this repo (under `node-hub/`) are published to the **Dora
+Hub** catalog, so you can pull one into a dataflow with a single line of YAML —
+no clone, no manual `path:` wiring:
+
+```yaml
+nodes:
+  - id: detector
+    hub: dora-yolo@^0.5      # resolved, pinned, and type-checked by `dora build`
+    inputs:
+      image: camera/image
+    outputs:
+      - bbox
+```
+
+`dora build` resolves the version requirement to an exact published version, pins
+it to a commit, and injects the node's typed input/output contracts into
+validation. Discover and inspect nodes with:
+
+```bash
+dora hub search yolo                 # find by name / keyword / category
+dora hub info dora-yolo              # contracts + a ready-to-paste example
+```
+
+See the **[Dora Hub guide](https://github.com/dora-rs/dora/blob/main/guide/src/hub/overview.md)**
+for version requirements, reproducible builds (`--locked`), publishing, and
+offline use. *(The `hub:` feature is currently unstable.)*
+
+### Publishing a node
+
+This repo is both the node **collection** (`node-hub/<name>/` source) and the
+**catalog** (`node-index/`, the published index entries). To publish a node you
+maintain here:
+
+```bash
+cd node-hub/my-node
+dora hub init               # scaffold a dora-node.yml manifest (if needed)
+dora hub publish --dry-run  # preview the exact index entry
+dora hub publish            # open the index PR
+```
+
+The catalog is append-only and CI-gated. See [`CONTRIBUTING.md`](CONTRIBUTING.md)
+for the workflow, [`node-index/README.md`](node-index/README.md) for the entry
+format, and [`node-index/POLICY.md`](node-index/POLICY.md) for namespaces and
+ownership.
+
 ## Packages
 
 > Feel free to modify this README with your own nodes so that it benefits the community.

--- a/node-index/README.md
+++ b/node-index/README.md
@@ -4,6 +4,8 @@ This directory is the **Dora Hub index**: a git-backed catalog mapping
 `[<namespace>/]<name>@<version>` to a node's manifest snapshot and a pointer to
 where its source lives. The `dora` CLI resolves `hub:` references against it.
 
+User guide: [Publishing a Node](https://github.com/dora-rs/dora/blob/main/guide/src/hub/publishing.md)
+and [Custom & Enterprise Indexes](https://github.com/dora-rs/dora/blob/main/guide/src/hub/indexes.md).
 Full design: [`docs/plan-node-hub.md` §7](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md)
 in `dora-rs/dora`.
 
@@ -64,6 +66,10 @@ and the publisher can't drift.
   ([`index-ci/reserved_namespaces.txt`](../index-ci/reserved_namespaces.txt) →
   needs an index admin) and a confusable/edit-distance check (→ human review),
   and always gets a human reviewer — see [`POLICY.md`](POLICY.md).
+- **Identity binding.** A newly-claimed namespace must match the claiming
+  author's GitHub identity — their own login, or an org they are a public member
+  of. Claiming another user's login is rejected (CI fails); an org claim that
+  can't be confirmed public is routed to human review rather than rejected.
 - **Owner identity.** The auto-merge bot merges a version only when it is
   published by an **owner** of its namespace (the `package.yml` OWNERS list,
   read from the base branch — a PR can't add itself as an owner and self-approve).


### PR DESCRIPTION
Documents the Dora Hub catalog in this repo's user-facing docs. The top-level README described dora-hub purely as a node **collection** — zero mentions of `hub:`, `dora hub`, or `node-index` — despite the repo now also being the Hub **catalog**.

## Changes
- **README.md** — new intro section: use a node with one line (`hub: dora-yolo@^0.5`), discover with `dora hub search`/`info`, and the publish flow; links the dora-repo Hub guide + the catalog docs. Existing node table/examples kept.
- **CONTRIBUTING.md** — removed the stale *"applies once PR #66 merges"* note (the catalog has landed); added the concrete `init -> validate -> publish` steps + a guide link.
- **node-index/README.md** — links the user guide (not just the internal spec) and documents the namespace **identity-binding** gate (#88).

## Notes
- Docs-only; `typos` clean.
- The `guide/src/hub/*` links resolve once dora-rs/dora#2260 (the Hub guide) merges — a deliberate forward reference to the sibling docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)